### PR TITLE
Don't error out for traffic that can't be forwarded

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -29,7 +29,7 @@ mod iptables;
 mod is_openwrt;
 mod link_local_tools;
 mod manipulate_uci;
-mod open_tunnel;
+pub mod open_tunnel;
 mod openwrt_ubus;
 mod ping_check;
 mod set_system_password;

--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -28,7 +28,7 @@ fn test_to_wg_local() {
     )
 }
 
-fn is_link_local(ip: IpAddr) -> bool {
+pub fn is_link_local(ip: IpAddr) -> bool {
     if let IpAddr::V6(ip) = ip {
         return (ip.segments()[0] & 0xffc0) == 0xfe80;
     }

--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -141,7 +141,7 @@ impl Handler<QueryExitDebts> for TrafficWatcher {
 
                                         DebtKeeper::from_registry().do_send(exit_replace);
                                     } else {
-                                        error!("The exit owes us? That shouldn't be possible!");
+                                        info!("The exit owes us? We must be a gateway!");
                                     }
                                 }
                                 Err(e) => {

--- a/rita/src/rita_common/traffic_watcher/mod.rs
+++ b/rita/src/rita_common/traffic_watcher/mod.rs
@@ -87,7 +87,7 @@ pub fn prepare_helper_maps(
 }
 
 pub fn get_babel_info(routes: Vec<Route>) -> Result<(HashMap<IpAddr, i128>, u32), Error> {
-    trace!("Got routes: {:?}", routes);
+    trace!("Got {} routes: {:?}", routes.len(), routes);
     let mut destinations = HashMap::new();
     // we assume this matches what is actually set it babel becuase we
     // panic on startup if it does not get set correctly
@@ -106,7 +106,10 @@ pub fn get_babel_info(routes: Vec<Route>) -> Result<(HashMap<IpAddr, i128>, u32)
                 };
 
                 //TODO gracefully handle exceeding max price
-                trace!("Inserting {} into the destiantons map", IpAddr::V6(ip.ip()));
+                trace!(
+                    "Inserting {} into the destinations map",
+                    IpAddr::V6(ip.ip())
+                );
                 destinations.insert(IpAddr::V6(ip.ip()), i128::from(price + local_fee));
             }
         }
@@ -119,6 +122,8 @@ pub fn get_babel_info(routes: Vec<Route>) -> Result<(HashMap<IpAddr, i128>, u32)
         },
         i128::from(0),
     );
+
+    trace!("{} destinations setup", destinations.len());
 
     Ok((destinations, local_fee))
 }

--- a/rita/src/rita_common/traffic_watcher/mod.rs
+++ b/rita/src/rita_common/traffic_watcher/mod.rs
@@ -12,6 +12,7 @@ use crate::rita_common::usage_tracker::UsageType;
 use crate::KI;
 use crate::SETTING;
 use ::actix::{Actor, Context, Handler, Message, Supervised, SystemService};
+use althea_kernel_interface::open_tunnel::is_link_local;
 use althea_kernel_interface::FilterTarget;
 use althea_types::Identity;
 use babel_monitor::Route;
@@ -20,7 +21,6 @@ use ipnetwork::IpNetwork;
 use settings::RitaCommonSettings;
 use std::collections::HashMap;
 use std::net::IpAddr;
-use althea_kernel_interface::open_tunnel::is_link_local;
 
 pub struct TrafficWatcher;
 
@@ -302,7 +302,10 @@ pub fn watch(routes: Vec<Route>, neighbors: &[Neighbor]) -> Result<(), Error> {
             }
             // this can be caused by a peer that has not yet formed a babel route
             // we use _ because ip_to_if is created from identites, if one fails the other must
-            (None, Some(if_to_id)) => warn!("We have an id {:?} but not destination for {}", if_to_id.mesh_ip, ip),
+            (None, Some(if_to_id)) => warn!(
+                "We have an id {:?} but not destination for {}",
+                if_to_id.mesh_ip, ip
+            ),
             // if we have a babel route we should have a peer it's possible we have a mesh client sneaking in?
             (Some(dest), None) => warn!("We have a destination {:?} but no id", dest),
             // dead entry?
@@ -327,7 +330,10 @@ pub fn watch(routes: Vec<Route>, neighbors: &[Neighbor]) -> Result<(), Error> {
             },
             // this can be caused by a peer that has not yet formed a babel route
             // we use _ because ip_to_if is created from identites, if one fails the other must
-            (None, Some(id_from_if)) => warn!("We have an id {:?} but not destination for {}", id_from_if.mesh_ip, ip),
+            (None, Some(id_from_if)) => warn!(
+                "We have an id {:?} but not destination for {}",
+                id_from_if.mesh_ip, ip
+            ),
             // if we have a babel route we should have a peer it's possible we have a mesh client sneaking in?
             (Some(dest), None) => warn!("We have a destination {:?} but no id", dest),
             // dead entry?
@@ -365,19 +371,17 @@ pub fn watch(routes: Vec<Route>, neighbors: &[Neighbor]) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::net::IpAddr;
     use std::net::Ipv6Addr;
-    use std::collections::HashMap;
-#[test]
-fn test_ip_lookup() {
-    let ip_a: IpAddr = "fd00::1337:e8f".parse().unwrap();
-    let ip_b: Ipv6Addr = "fd00::1337:e8f".parse().unwrap();
-    let ip_b = IpAddr::V6(ip_b);
-    assert_eq!(ip_a, ip_b);
-    let mut map = HashMap::new();
-    map.insert(ip_b, "test");
-    assert!(map.get(&ip_a) != None);
-
-
-}
+    #[test]
+    fn test_ip_lookup() {
+        let ip_a: IpAddr = "fd00::1337:e8f".parse().unwrap();
+        let ip_b: Ipv6Addr = "fd00::1337:e8f".parse().unwrap();
+        let ip_b = IpAddr::V6(ip_b);
+        assert_eq!(ip_a, ip_b);
+        let mut map = HashMap::new();
+        map.insert(ip_b, "test");
+        assert!(map.get(&ip_a) != None);
+    }
 }


### PR DESCRIPTION
Our logs are filled with error messages for linklocal undeliverable
traffic, since this traffic can't go anywhere it can't be billed
in a pay per forward system and should be more gracefully ignored.