### PR TITLE
Bump up pay threshold in tests to prevent race condition

### DIFF
--- a/settings/default.toml
+++ b/settings/default.toml
@@ -1,5 +1,5 @@
 [payment]
-pay_threshold = "0"
+pay_threshold = "10000000000000"
 close_threshold = "-10000000000000"
 close_fraction = "100"
 buffer_period = 3

--- a/settings/default_exit.toml
+++ b/settings/default_exit.toml
@@ -3,7 +3,7 @@ workers = 1
 description = "just a normal althea exit"
 
 [payment]
-pay_threshold = "0"
+pay_threshold = "10000000000000"
 close_threshold = "-10000000000000"
 close_fraction = "100"
 buffer_period = 3


### PR DESCRIPTION
It's possible that we mesure debts in between an attempt to pay
and the resulting failure of that attempt.