### PR TITLE
Free tier with toggle

### DIFF
--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -370,10 +370,9 @@ fn exit_status_request(exit: String) -> impl Future<Item = (), Error = Error> {
 /// An actor which pays the exit
 #[derive(Default)]
 pub struct ExitManager {
-    // used to determine if we need to change the logging state
+    // used to determine if we need to change the logging state and if we've changed exits
     last_exit: Option<ExitServer>,
-    // the logging destination
-    dest_url: String,
+    nat_setup: bool,
     // if we are currently limiting our own connection speed due to a low balance.
     local_limiting: bool,
 }
@@ -387,7 +386,6 @@ impl SystemService for ExitManager {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
         info!("Exit Manager started");
         self.last_exit = None;
-        self.dest_url = SETTING.get_log().dest_url.clone();
         self.local_limiting = false;
     }
 }
@@ -396,8 +394,10 @@ impl Handler<Tick> for ExitManager {
     type Result = ResponseFuture<(), Error>;
 
     fn handle(&mut self, _: Tick, _ctx: &mut Context<Self>) -> Self::Result {
-        // strange notication lets us scope our access to SETTING and prevent
+        // scopes our access to SETTING and prevent
         // holding a readlock while exit tunnel setup requires a write lock
+        // roughly the same as a drop(); inline
+        let client_can_use_free_tier = { SETTING.get_payment().client_can_use_free_tier };
         let exit_server = { SETTING.get_exit_client().get_current_exit().cloned() };
 
         // code that connects to the current exit server
@@ -406,39 +406,65 @@ impl Handler<Tick> for ExitManager {
             trace!("We have selected an exit!");
             if let Some(general_details) = exit.info.clone().general_details() {
                 trace!("We have details for the selected exit!");
-                // only run if we have our own details and we either have no setup exit or the chosen
-                // exit has changed, if all of that is good we check if the default route is still correct
-                // and change it again if it's not.
-                if exit.info.our_details().is_some()
-                    && !(self.last_exit.is_some() && self.last_exit.clone().unwrap() == exit)
-                {
-                    trace!("Exit change, setting up exit tunnel");
-                    linux_setup_exit_tunnel(
-                        &exit,
-                        &general_details.clone(),
-                        &exit.info.our_details().unwrap(),
-                    )
-                    .expect("failure setting up exit tunnel");
 
-                    self.last_exit = Some(exit.clone());
-                } else if exit.info.our_details().is_some()
-                    && !KI
-                        .get_default_route()
-                        .unwrap_or_default()
-                        .contains(&String::from("wg_exit"))
-                {
-                    trace!("DHCP overwrite setup exit tunnel again");
-                    trace!("Exit change, setting up exit tunnel");
-                    linux_setup_exit_tunnel(
-                        &exit,
-                        &general_details.clone(),
-                        &exit.info.our_details().unwrap(),
-                    )
-                    .expect("failure setting up exit tunnel");
+                let signed_up_for_exit = exit.info.our_details().is_some();
+                let exit_has_changed =
+                    !(self.last_exit.is_some() && self.last_exit.clone().unwrap() == exit);
+                let correct_default_route = KI
+                    .get_default_route()
+                    .unwrap_or_default()
+                    .contains(&String::from("wg_exit"));
+
+                match (signed_up_for_exit, exit_has_changed, correct_default_route) {
+                    (true, true, _) => {
+                        trace!("Exit change, setting up exit tunnel");
+                        linux_setup_exit_tunnel(
+                            &exit,
+                            &general_details.clone(),
+                            &exit.info.our_details().unwrap(),
+                        )
+                        .expect("failure setting up exit tunnel");
+                        self.nat_setup = true;
+                        self.last_exit = Some(exit.clone());
+                    }
+                    (true, false, false) => {
+                        trace!("DHCP overwrite setup exit tunnel again");
+                        linux_setup_exit_tunnel(
+                            &exit,
+                            &general_details.clone(),
+                            &exit.info.our_details().unwrap(),
+                        )
+                        .expect("failure setting up exit tunnel");
+                        self.nat_setup = true;
+                    }
+                    _ => {}
+                }
+
+                // Adds and removes the nat rules in low balance situations
+                // this prevents the free tier from being confusing (partially working)
+                // when deployments are not interested in having a sufficiently fast one
+                let low_balance = low_balance();
+                let nat_setup = self.nat_setup;
+                match (low_balance, client_can_use_free_tier, nat_setup) {
+                    (true, false, true) => {
+                        let lan_nics = &SETTING.get_exit_client().lan_nics;
+                        for nic in lan_nics {
+                            KI.delete_client_nat_rules(&nic).unwrap();
+                        }
+                        self.nat_setup = false;
+                    }
+                    (false, _, false) => {
+                        let lan_nics = &SETTING.get_exit_client().lan_nics;
+                        for nic in lan_nics {
+                            KI.add_client_nat_rules(&nic).unwrap();
+                        }
+                        self.nat_setup = true;
+                    }
+                    _ => {}
                 }
 
                 // run billing at all times when an exit is setup
-                if self.last_exit.is_some() {
+                if signed_up_for_exit {
                     let exit_price = general_details.exit_price;
                     let exit_internal_addr = general_details.server_internal_ip;
                     let exit_port = exit.registration_port;

--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -370,11 +370,9 @@ fn exit_status_request(exit: String) -> impl Future<Item = (), Error = Error> {
 /// An actor which pays the exit
 #[derive(Default)]
 pub struct ExitManager {
-    // used to determine if we need to change the logging state and if we've changed exits
+    // used to determine if we've changed exits
     last_exit: Option<ExitServer>,
     nat_setup: bool,
-    // if we are currently limiting our own connection speed due to a low balance.
-    local_limiting: bool,
 }
 
 impl Actor for ExitManager {
@@ -386,7 +384,6 @@ impl SystemService for ExitManager {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
         info!("Exit Manager started");
         self.last_exit = None;
-        self.local_limiting = false;
     }
 }
 

--- a/settings/src/logging.rs
+++ b/settings/src/logging.rs
@@ -27,9 +27,9 @@ pub struct LoggingSettings {
 impl Default for LoggingSettings {
     fn default() -> Self {
         LoggingSettings {
-            enabled: true,
-            level: "INFO".to_string(),
-            dest_url: "https://stats.altheamesh.com:9999/sink/".to_string(),
+            enabled: default_logging(),
+            level: default_logging_level(),
+            dest_url: default_logging_dest_url(),
         }
     }
 }

--- a/settings/src/network.rs
+++ b/settings/src/network.rs
@@ -6,7 +6,6 @@ use althea_types::WgKey;
 use arrayvec::ArrayString;
 
 fn default_discovery_ip() -> Ipv6Addr {
-    warn!("Add discovery_ip to network, removed in the next version!");
     Ipv6Addr::new(0xff02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x8)
 }
 

--- a/settings/src/network.rs
+++ b/settings/src/network.rs
@@ -44,8 +44,6 @@ pub struct NetworkSettings {
     /// The static IP used on mesh interfaces
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh_ip: Option<IpAddr>,
-    /// Mesh IP of bounty hunter (in fd00::/8)
-    pub bounty_ip: IpAddr,
     /// Broadcast ip address used for peer discovery (in ff02::/8)
     #[serde(default = "default_discovery_ip")]
     pub discovery_ip: Ipv6Addr,
@@ -128,7 +126,6 @@ impl Default for NetworkSettings {
             backup_created: false,
             metric_factor: default_metric_factor(),
             mesh_ip: None,
-            bounty_ip: "fd00::3".parse().unwrap(),
             discovery_ip: default_discovery_ip(),
             babel_port: 6872,
             rita_hello_port: 4876,

--- a/settings/src/payment.rs
+++ b/settings/src/payment.rs
@@ -130,28 +130,28 @@ pub struct PaymentSettings {
 impl Default for PaymentSettings {
     fn default() -> Self {
         PaymentSettings {
-            local_fee: 3000000,
-            max_fee: 73333333,
-            dynamic_fee_multiplier: 20,
-            free_tier_throughput: 1000,
+            local_fee: default_local_fee(),
+            max_fee: default_max_fee(),
+            dynamic_fee_multiplier: default_dynamic_fee_multiplier(),
+            free_tier_throughput: default_free_tier_throughput(),
             // computed as 10x the standard transaction cost on 12/2/18
-            pay_threshold: 840_000_000_000_000i64.into(),
+            pay_threshold: default_pay_threshold(),
             // computed as 10x the pay threshold
-            close_threshold: (-8_400_000_000_000_000i64).into(),
-            balance_warning_level: (10_000_000_000_000_000u64).into(),
+            close_threshold: default_close_threshold(),
+            balance_warning_level: default_balance_warning_level(),
             eth_private_key: None,
             eth_address: None,
             balance: 0u64.into(),
             nonce: 0u64.into(),
-            gas_price: 10000000000u64.into(), // 10 gwei
+            gas_price: 0u64.into(), // 10 gwei
             net_version: None,
             node_list: Vec::new(),
-            system_chain: SystemChain::Ethereum,
-            withdraw_chain: SystemChain::Ethereum,
+            system_chain: default_system_chain(),
+            withdraw_chain: default_system_chain(),
             debts_file: default_debts_file(),
-            bridge_enabled: true,
+            bridge_enabled: default_bridge_enabled(),
             fudge_factor: 0u8,
-            debt_limit_enabled: true,
+            debt_limit_enabled: default_debt_limit_enabled(),
         }
     }
 }

--- a/settings/src/payment.rs
+++ b/settings/src/payment.rs
@@ -30,6 +30,10 @@ fn default_free_tier_throughput() -> u32 {
     1000
 }
 
+fn default_client_can_use_free_tier() -> bool {
+    true
+}
+
 fn default_bridge_enabled() -> bool {
     true
 }
@@ -74,6 +78,10 @@ pub struct PaymentSettings {
     /// Throughput of the free tier that this node provides in kbit/s
     #[serde(default = "default_free_tier_throughput")]
     pub free_tier_throughput: u32,
+    /// If this is True the user may perform regular web browsing on the free tier, if it is
+    /// false the NAT rule will be removed while the router is in the low balance state
+    #[serde(default = "default_client_can_use_free_tier")]
+    pub client_can_use_free_tier: bool,
     /// The threshold above which we will kick off a payment
     #[serde(default = "default_pay_threshold")]
     pub pay_threshold: Int256,
@@ -134,6 +142,7 @@ impl Default for PaymentSettings {
             max_fee: default_max_fee(),
             dynamic_fee_multiplier: default_dynamic_fee_multiplier(),
             free_tier_throughput: default_free_tier_throughput(),
+            client_can_use_free_tier: default_client_can_use_free_tier(),
             // computed as 10x the standard transaction cost on 12/2/18
             pay_threshold: default_pay_threshold(),
             // computed as 10x the pay threshold


### PR DESCRIPTION
This adds a toggle to the free tier feature to prevent it from being user facing (eg allowing user devices to operate on the free tier bandwidth allocation). In the field we've found that users with lots of devices will experience very intermittent connections rather than slow connections. It's better the user has no internet and must search for the cause than they have bad internet. 