### PR TITLE
More aggressive tunnel timeout

### DIFF
--- a/settings/src/network.rs
+++ b/settings/src/network.rs
@@ -11,7 +11,7 @@ fn default_discovery_ip() -> Ipv6Addr {
 }
 
 fn default_tunnel_timeout() -> u64 {
-    900 // 15 minutes
+    300 // 5 minutes
 }
 
 fn default_metric_factor() -> u32 {


### PR DESCRIPTION
In the case where a router is restarting consantly on the cron timeout
the 10 minute cron job will eventually exhaust the tunnel supply of upstream
routers. This settings tweak will allow us to maintain functionality in that
situation indefinately. Now if that's acutally a good idea remains to be seen.