### PR TITLE
Use the 'metro' tuning for Cake by default

### DIFF
--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -111,7 +111,7 @@ impl dyn KernelInterface {
         let output = self.run_command(
             "tc",
             &[
-                "qdisc", "add", "dev", iface_name, "root", "handle", "1:", "cake",
+                "qdisc", "add", "dev", iface_name, "root", "handle", "1:", "cake", "metro",
             ],
         )?;
 
@@ -122,6 +122,7 @@ impl dyn KernelInterface {
                 "tc",
                 &[
                     "qdisc", "add", "dev", iface_name, "root", "handle", "1:", "fq_codel",
+                    "target", "10ms",
                 ],
             )?;
 


### PR DESCRIPTION
Most of our links have a average latency between 1ms and 10ms the default
'internet' value of the per hop tunnel Codel target was grossly off base.
This was hidden by the shaping on exit tunnels (which worked) and the shaping
for throughput constrained devices (which also worked). This issue was only
encountered when we had a throughput limited link that was saturated by more
than a single exit tunnel at a time.