### PR TITLE
cake as leaf qdisc

### DIFF
--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -262,11 +262,33 @@ impl dyn KernelInterface {
             ],
         )?;
 
+        if !output.status.success() {
+            let res = String::from_utf8(output.stderr)?;
+            bail!("Failed to update qdisc class limit! {:?}", res);
+        }
+
+        let output = self.run_command(
+            "tc",
+            &[
+                "qdisc",
+                modifier,
+                "dev",
+                iface_name,
+                "parent",
+                &format!("1:{}", class_id),
+                "handle",
+                &format!("{}:", class_id),
+                "fq_codel",
+                "quantum",
+                "1354",
+            ],
+        )?;
+
         if output.status.success() {
             Ok(())
         } else {
             let res = String::from_utf8(output.stderr)?;
-            bail!("Failed to update qdisc class limit! {:?}", res);
+            bail!("Failed to update qdisc codel leaf limit! {:?}", res);
         }
     }
 

--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -278,18 +278,16 @@ impl dyn KernelInterface {
                 &format!("1:{}", class_id),
                 "handle",
                 &format!("{}:", class_id),
-                "fq_codel",
-                "quantum",
-                "1354",
+                "cake",
+                "metro",
             ],
         )?;
 
-        if output.status.success() {
-            Ok(())
-        } else {
+        if !output.status.success() {
             let res = String::from_utf8(output.stderr)?;
-            bail!("Failed to update qdisc codel leaf limit! {:?}", res);
+            warn!("Operating system does not support cake :( {:?}", res);
         }
+        Ok(())
     }
 
     /// Generates a unique traffic class id for a exit user, essentially a really dumb hashing function

--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -352,3 +352,9 @@ impl dyn KernelInterface {
         }
     }
 }
+
+#[test]
+fn get_id() {
+    use crate::KI;
+    println!("{}", KI.get_class_id(&"172.168.4.121".parse().unwrap()));
+}


### PR DESCRIPTION
This adds codel as the leaf qdisc to the exit htb setup. I don't
think this is actually doing much over pfifo-fast in it's current form
though