### PR TITLE
Add github actions caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Check Rita and Rita Exit x86
         run: cargo check --all
   test:
@@ -21,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Run Rita and Rita Exit tests
         run: RUST_TEST_THREADS=1 cargo test --verbose --all
   rustfmt:
@@ -35,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Check for Clippy lints
         run: rustup component add clippy && cargo clippy --all --all-targets --all-features -- -D warnings
   cross-mips:
@@ -42,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test mips
         run: cargo install cross && cross test --target mips-unknown-linux-musl --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   cross-mipsel:
@@ -49,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test mipsel
         run: cargo install cross && cross test --target mipsel-unknown-linux-musl --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   cross-mips64:
@@ -56,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test mips64
         run: cargo install cross && cross test --target mips64-unknown-linux-gnuabi64 --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   cross-mips64el:
@@ -63,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test mips64el
         run: cargo install cross && cross test --target mips64el-unknown-linux-gnuabi64 --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   cross-aarch64:
@@ -70,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test aarch64
         run: cargo install cross && cross test --target aarch64-unknown-linux-musl --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   cross-armv7:
@@ -77,6 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
       - name: Cross test armv7
         run: cargo install cross && cross test --target armv7-unknown-linux-musleabihf --verbose -p rita_bin --bin rita --features bundle_openssl -- --test-threads=1
   integration-test-with-backcompat:
@@ -84,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Install Wireguard
         run: sudo apt-get update && sudo apt install -y wireguard linux-source linux-headers-$(uname -r) build-essential && sudo modprobe wireguard
       - name: Run integration test
@@ -93,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Install Wireguard
         run: sudo apt-get update && sudo apt install -y wireguard linux-source linux-headers-$(uname -r) build-essential && sudo modprobe wireguard
       - name: Run integration test

--- a/integration-tests/container/Dockerfile
+++ b/integration-tests/container/Dockerfile
@@ -12,7 +12,6 @@ ARG NODES
 ENV SPEEDTEST_THROUGHPUT=$SPEEDTEST_THROUGHPUT
 ENV SPEEDTEST_DURATION=$SPEEDTEST_DURATION
 ENV VERBOSE=$VERBOSE
-RUN PATH=$PATH:$HOME/.cargo/bin cargo install diesel_cli --force
 ENV NODES=$NODES
 # we pull in the git tar instead of the local folder becuase the raw code is much much smaller
 # note that changes have to be checked in to be pulled in and tested! we pull this in near

--- a/integration-tests/container/Dockerfile
+++ b/integration-tests/container/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y sudo iputils-ping iproute2 jq vim netca
 RUN apt-get install -y -t unstable iperf3
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV POSTGRES_USER=postgres
-ENV POSTGRES_BIN=/usr/lib/postgresql/13/bin/postgres
-ENV INITDB_BIN=/usr/lib/postgresql/13/bin/initdb
+ENV POSTGRES_BIN=/usr/lib/postgresql/14/bin/postgres
+ENV INITDB_BIN=/usr/lib/postgresql/14/bin/initdb
 RUN PATH=$PATH:$HOME/.cargo/bin cargo install diesel_cli --force
 ARG NODES
 ENV SPEEDTEST_THROUGHPUT=$SPEEDTEST_THROUGHPUT


### PR DESCRIPTION
This patch adds basic Docker layer caching and Rust build caching. This
should dramatically reduce build times and hopefully not introduce too
many cache errors.