### PR TITLE
Thosmos/settings adaptor

### DIFF
--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -111,6 +111,19 @@ impl dyn KernelInterface {
 
         Ok(ret)
     }
+
+    /// calls iproute2 to set an interface up or down
+    pub fn set_if_up_down(&self, if_name: &str, up_down: &str) -> Result<(), Error> {
+        let output = self.run_command("ip", &["link", "set", "dev", if_name, up_down])?;
+        if !output.stderr.is_empty() {
+            return Err(Error::RuntimeError(format!(
+                "received error setting wg interface up: {}",
+                String::from_utf8(output.stderr)?
+            )));
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[test]

--- a/althea_kernel_interface/src/ip_addr.rs
+++ b/althea_kernel_interface/src/ip_addr.rs
@@ -43,6 +43,36 @@ impl dyn KernelInterface {
             ))),
         }
     }
+
+    /// Adds an ipv4 address to a given interface, true is returned when
+    /// the ip is added, false if it is already there and Error if the interface
+    /// does not exist or some other error has occured
+    pub fn add_ipv4_mask(&self, ip: Ipv4Addr, mask: u32, dev: &str) -> Result<bool, Error> {
+        // upwrap here because it's ok if we panic when the system does not have 'ip' installed
+        let output = self
+            .run_command(
+                "ip",
+                &["addr", "add", &format!("{}/{}", ip, mask), "dev", dev],
+            )
+            .unwrap();
+        // Get the first line, check if it has "file exists"
+        match String::from_utf8(output.stderr) {
+            Ok(stdout) => match stdout.lines().next() {
+                Some(line) => {
+                    if line.contains("File exists") {
+                        Ok(false)
+                    } else {
+                        Err(Error::RuntimeError(format!("Error setting ip {}", line)))
+                    }
+                }
+                None => Ok(true),
+            },
+            Err(e) => Err(Error::RuntimeError(format!(
+                "Could not decode stderr from ip with {:?}",
+                e
+            ))),
+        }
+    }
 }
 
 #[test]

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -53,6 +53,8 @@ fn main() {
     .unwrap_or_else(|e| e.exit());
 
     let settings_file = args.flag_config;
+    println!("Settings file {}", settings_file);
+
     wait_for_settings(&settings_file);
 
     // load the settings file, setup a thread to save it out every so often

--- a/rita_client/src/dashboard/backup_created.rs
+++ b/rita_client/src/dashboard/backup_created.rs
@@ -1,7 +1,6 @@
 use actix_web::Path;
 use actix_web::{HttpRequest, HttpResponse, Result};
 use failure::Error;
-use settings::FileWrite;
 use std::collections::HashMap;
 
 pub fn get_backup_created(_req: HttpRequest) -> Result<HttpResponse, Error> {
@@ -22,18 +21,13 @@ pub fn set_backup_created(path: Path<bool>) -> Result<HttpResponse, Error> {
     debug!("Setting backup created");
     let value = path.into_inner();
 
-    let mut network = settings::get_rita_client().network;
-    network.backup_created = value;
-
-    // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(e) = rita_client.write(&settings::get_flag_config()) {
-        return Err(e);
-    } else {
-        settings::set_rita_client(rita_client);
-    }
     let mut rita_client = settings::get_rita_client();
-    rita_client.network = network;
+    rita_client.network.backup_created = value;
     settings::set_rita_client(rita_client);
+
+    if let Err(e) = settings::write_config() {
+        return Err(e);
+    }
+
     Ok(HttpResponse::Ok().json(()))
 }

--- a/rita_client/src/dashboard/bandwidth_limit.rs
+++ b/rita_client/src/dashboard/bandwidth_limit.rs
@@ -5,7 +5,6 @@ use actix_web::HttpResponse;
 use actix_web::{HttpRequest, Path};
 use failure::Error;
 use rita_common::KI;
-use settings::FileWrite;
 
 pub fn get_bandwidth_limit(_req: HttpRequest) -> HttpResponse {
     let val = settings::get_rita_client().network.user_bandwidth_limit;
@@ -29,12 +28,8 @@ pub fn set_bandwidth_limit(path: Path<String>) -> Result<HttpResponse, Error> {
     rita_client.network = network;
     settings::set_rita_client(rita_client);
 
-    // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(e) = rita_client.write(&settings::get_flag_config()) {
+    if let Err(e) = settings::write_config() {
         return Err(e);
-    } else {
-        settings::set_rita_client(rita_client);
     }
     Ok(HttpResponse::Ok().json(()))
 }

--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -16,7 +16,6 @@ use futures01::{future, Future};
 use rita_common::dashboard::Dashboard;
 use rita_common::KI;
 use settings::client::ExitServer;
-use settings::FileWrite;
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -204,13 +203,9 @@ pub fn select_exit(path: Path<String>) -> Box<dyn Future<Item = HttpResponse, Er
         rita_client.exit_client = exit_client;
         settings::set_rita_client(rita_client);
 
-        // try and save the config and fail if we can't, this way we can run the save
-        // loop less often and not lose exit configs
-        let temp_client = settings::get_rita_client();
-        if let Err(e) = temp_client.write(&settings::get_flag_config()) {
+        // try and save the config and fail if we can't
+        if let Err(e) = settings::write_config() {
             return Box::new(future::err(e));
-        } else {
-            settings::set_rita_client(temp_client);
         }
 
         Box::new(future::ok(HttpResponse::Ok().json(ret)))

--- a/rita_client/src/dashboard/installation_details.rs
+++ b/rita_client/src/dashboard/installation_details.rs
@@ -3,7 +3,6 @@ use actix_web::{HttpRequest, Json, Path};
 use althea_types::ContactType;
 use althea_types::InstallationDetails;
 use althea_types::{BillingDetails, MailingAddress};
-use settings::FileWrite;
 
 /// This is a utility type that is used by the front end when sending us
 /// installation details. This lets us do the validation and parsing here
@@ -121,12 +120,8 @@ pub fn set_installation_details(req: Json<InstallationDetailsPost>) -> HttpRespo
     rita_client.operator = operator;
     settings::set_rita_client(rita_client);
 
-    // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
+    if let Err(_e) = settings::write_config() {
         return HttpResponse::InternalServerError().finish();
-    } else {
-        settings::set_rita_client(rita_client);
     }
     HttpResponse::Ok().finish()
 }
@@ -153,12 +148,10 @@ pub fn set_display_operator_setup(val: Path<bool>) -> HttpResponse {
     }
 
     // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
+    if let Err(_e) = settings::write_config() {
         return HttpResponse::InternalServerError().finish();
-    } else {
-        settings::set_rita_client(rita_client);
     }
+
     HttpResponse::Ok().finish()
 }
 

--- a/rita_client/src/dashboard/interfaces.rs
+++ b/rita_client/src/dashboard/interfaces.rs
@@ -5,7 +5,6 @@ use failure::bail;
 use failure::Error;
 use rita_common::peer_listener::unlisten_interface;
 use rita_common::KI;
-use settings::FileWrite;
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 
@@ -349,8 +348,7 @@ pub fn ethernet_transform_mode(
     settings::set_rita_client(rita_client);
 
     // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
+    if let Err(_e) = settings::write_config() {
         return Err(_e);
     }
 

--- a/rita_client/src/dashboard/logging.rs
+++ b/rita_client/src/dashboard/logging.rs
@@ -3,7 +3,6 @@ use actix_web::{HttpRequest, HttpResponse, Path};
 use failure::Error;
 use log::LevelFilter;
 use rita_common::KI;
-use settings::FileWrite;
 
 pub fn get_remote_logging(_req: HttpRequest) -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().json(settings::get_rita_client().log.enabled))
@@ -16,14 +15,14 @@ pub fn remote_logging(path: Path<bool>) -> Result<HttpResponse, Error> {
     // try and save the config and fail if we can't
     let mut rita_client = settings::get_rita_client();
 
-    let mut log = settings::get_rita_client().log;
-    log.enabled = enabled;
-    rita_client.log = log;
+    rita_client.log.enabled = enabled;
     settings::set_rita_client(rita_client);
 
-    if let Err(e) = settings::get_rita_client().write(&settings::get_flag_config()) {
+    if let Err(e) = settings::write_config() {
         return Err(e);
     }
+
+    // FIXME get binary name from somewhere
     if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
         return Err(e.into());
     }
@@ -50,18 +49,16 @@ pub fn remote_logging_level(path: Path<String>) -> Result<HttpResponse, Error> {
         }
     };
 
-    let mut log = settings::get_rita_client().log;
-    log.level = log_level.to_string();
     let mut rita_client = settings::get_rita_client();
-    rita_client.log = log;
+
+    rita_client.log.level = log_level.to_string();
     settings::set_rita_client(rita_client);
 
-    // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
-        return Err(_e);
+    if let Err(e) = settings::write_config() {
+        return Err(e);
     }
 
+    // FIXME get binary name from somewhere
     if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
         return Err(e.into());
     }

--- a/rita_client/src/dashboard/logging.rs
+++ b/rita_client/src/dashboard/logging.rs
@@ -16,15 +16,21 @@ pub fn remote_logging(path: Path<bool>) -> Result<HttpResponse, Error> {
     let mut rita_client = settings::get_rita_client();
 
     rita_client.log.enabled = enabled;
+
+    let service_path: String = format!("/etc/init.d/{}", rita_client.app_name);
+
     settings::set_rita_client(rita_client);
 
     if let Err(e) = settings::write_config() {
-        return Err(e);
+        return Ok(HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .into_builder()
+            .json(format!("Failed to write config {:?}", e)));
     }
 
-    // FIXME get binary name from somewhere
-    if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
-        return Err(e.into());
+    if let Err(e) = KI.run_command(service_path.as_str(), &["restart"]) {
+        return Ok(HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .into_builder()
+            .json(format!("Failed to restart service {:?}", e)));
     }
 
     Ok(HttpResponse::Ok().json(()))
@@ -52,15 +58,21 @@ pub fn remote_logging_level(path: Path<String>) -> Result<HttpResponse, Error> {
     let mut rita_client = settings::get_rita_client();
 
     rita_client.log.level = log_level.to_string();
+
+    let service_path: String = format!("/etc/init.d/{}", rita_client.app_name);
+
     settings::set_rita_client(rita_client);
 
     if let Err(e) = settings::write_config() {
-        return Err(e);
+        return Ok(HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .into_builder()
+            .json(format!("Failed to write config {:?}", e)));
     }
 
-    // FIXME get binary name from somewhere
-    if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
-        return Err(e.into());
+    if let Err(e) = KI.run_command(service_path.as_str(), &["restart"]) {
+        return Ok(HttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR)
+            .into_builder()
+            .json(format!("Failed to restart service {:?}", e)));
     }
 
     Ok(HttpResponse::Ok().json(()))

--- a/rita_client/src/dashboard/notifications.rs
+++ b/rita_client/src/dashboard/notifications.rs
@@ -1,6 +1,5 @@
 use ::actix_web::Path;
 use ::actix_web::{HttpRequest, HttpResponse};
-use settings::FileWrite;
 
 pub fn get_low_balance_notification(_req: HttpRequest) -> HttpResponse {
     let setting = settings::get_rita_client()
@@ -14,14 +13,13 @@ pub fn set_low_balance_notification(path: Path<bool>) -> HttpResponse {
     let value = path.into_inner();
     debug!("Set low balance notification hit!");
 
-    let mut exit_client = settings::get_rita_client().exit_client;
-    exit_client.low_balance_notification = value;
     let mut rita_client = settings::get_rita_client();
-    rita_client.exit_client = exit_client;
+    // let mut exit_client = rita_client.exit_client;
+    rita_client.exit_client.low_balance_notification = value;
+    // rita_client.exit_client = exit_client;
     settings::set_rita_client(rita_client);
 
-    // try and save the config and fail if we can't
-    if let Err(_e) = settings::get_rita_client().write(&settings::get_flag_config()) {
+    if let Err(_e) = settings::write_config() {
         return HttpResponse::InternalServerError().finish();
     }
 

--- a/rita_client/src/dashboard/prices.rs
+++ b/rita_client/src/dashboard/prices.rs
@@ -2,7 +2,6 @@ use actix_web::Path;
 use actix_web::{HttpRequest, HttpResponse, Json, Result};
 use failure::Error;
 use num256::Uint256;
-use settings::FileWrite;
 
 use crate::traffic_watcher::get_exit_dest_price;
 pub fn auto_pricing_status(_req: HttpRequest) -> Result<Json<bool>, Error> {
@@ -24,12 +23,8 @@ pub fn set_auto_pricing(path: Path<bool>) -> Result<HttpResponse, Error> {
     settings::set_rita_client(rita_client);
 
     // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
-        return Err(_e);
-    } else {
-        settings::set_rita_client(rita_client);
-    }
+    settings::write_config()?;
+
     Ok(HttpResponse::Ok().json(()))
 }
 

--- a/rita_client/src/dashboard/system_chain.rs
+++ b/rita_client/src/dashboard/system_chain.rs
@@ -8,7 +8,6 @@ use settings::payment::ETH_FEE_MULTIPLIER;
 use settings::payment::ETH_MIN_GAS;
 use settings::payment::XDAI_FEE_MULTIPLIER;
 use settings::payment::XDAI_MIN_GAS;
-use settings::FileWrite;
 
 /// Changes the full node configuration value between test/prod and other networks
 pub fn set_system_blockchain_endpoint(path: Path<String>) -> Result<HttpResponse, Error> {
@@ -20,19 +19,14 @@ pub fn set_system_blockchain_endpoint(path: Path<String>) -> Result<HttpResponse
             .json(format!("Could not parse {:?} into a SystemChain enum!", id)));
     }
     let id = id.unwrap();
+
     let mut rita_client = settings::get_rita_client();
     let mut payment = rita_client.payment;
     set_system_blockchain(id, &mut payment);
     rita_client.payment = payment;
     settings::set_rita_client(rita_client);
 
-    // try and save the config and fail if we can't
-    let rita_client = settings::get_rita_client();
-    if let Err(_e) = rita_client.write(&settings::get_flag_config()) {
-        return Err(_e);
-    } else {
-        settings::set_rita_client(rita_client);
-    }
+    settings::write_config()?;
 
     Ok(HttpResponse::Ok().json(()))
 }

--- a/rita_client/src/lib.rs
+++ b/rita_client/src/lib.rs
@@ -42,23 +42,33 @@ pub use crate::dashboard::router::*;
 pub use crate::dashboard::system_chain::*;
 pub use crate::dashboard::usage;
 pub use crate::dashboard::wifi::*;
-use settings::client::RitaClientSettings;
+use settings::client::{default_config_path, RitaClientSettings, APP_NAME};
 use std::time::{Duration, Instant};
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub struct Args {
+    #[serde(default = "default_config_path")]
     pub flag_config: String,
     pub flag_platform: String,
     pub flag_future: bool,
 }
 
-// TODO we should remove --platform as it's not used, but that requires
-// changing how rita is invoked everywhere, because that's difficult
-// with in the field routers this is waiting on another more pressing
-// upgrade to the init file for Rita on the routers
+impl Default for Args {
+    fn default() -> Self {
+        Args {
+            flag_config: default_config_path(),
+            flag_platform: "linux".to_string(),
+            flag_future: false,
+        }
+    }
+}
+
+/// TODO platform is in the process of being removed as a support argument
+/// as it's not even used. Config can still be used but has a sane default
+/// and does not need to be specified.
 pub fn get_client_usage(version: &str, git_hash: &str) -> String {
     format!(
-        "Usage: rita --config=<settings> --platform=<platform> [--future]
+        "Usage: {} [--config=<settings>] [--platform=<platform>] [--future]
 Options:
     -c, --config=<settings>     Name of config file
     -p, --platform=<platform>   Platform (linux or OpenWrt)
@@ -66,7 +76,7 @@ Options:
 About:
     Version {} - {}
     git hash {}",
-        READABLE_VERSION, version, git_hash
+        APP_NAME, READABLE_VERSION, version, git_hash
     )
 }
 

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -14,6 +14,16 @@ use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::path::Path;
 
+pub const APP_NAME: &str = "rita";
+
+pub fn default_app_name() -> String {
+    APP_NAME.to_string()
+}
+
+pub fn default_config_path() -> String {
+    format!("/etc/{}.toml", APP_NAME)
+}
+
 /// This struct is used by rita to store exit specific information
 /// There is one instance per exit
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -197,6 +207,8 @@ pub struct RitaClientSettings {
     pub exit_client: ExitClientSettings,
     #[serde(skip)]
     pub future: bool,
+    #[serde(default = "default_app_name")]
+    pub app_name: String,
 }
 
 impl RitaClientSettings {

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -95,8 +95,6 @@ pub trait WrappedSettingsAdaptor {
     fn write_config(&self) -> Result<(), Error>;
     fn merge_client_json(&self, changed_settings: serde_json::Value) -> Result<(), Error>;
     fn get_config_json(&self) -> Result<serde_json::Value, Error>;
-    // fn read_client(&self) -> Result<RitaClientSettings, Error>;
-    // fn test(&self, arg: i32);
 }
 
 // This function can be called from a higher layer to set a reference to its adaptor

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -430,6 +430,7 @@ pub fn update_config(
         network: old_settings.network,
         exit_client: old_settings.exit_client.clone(),
         future: old_settings.future,
+        app_name: old_settings.app_name,
     };
 
     // we have already updated to reading the new settings


### PR DESCRIPTION
This adds a WrappedSettingsAdaptor that allows settings to be handled by a higher layer that wraps RitaClientSettings and adds its own additional fields.  The higher layer is responsible for the actual read/write of settings to disk.

This also cleaned up a bunch of strange settings read/writes in the dashboard http handlers.  In testing it seems to be more snappy.

This has been tested with a wrapping binary for verification.