### PR TITLE
Fix and clean up usage tracker

### DIFF
--- a/rita_client/src/dashboard/usage.rs
+++ b/rita_client/src/dashboard/usage.rs
@@ -1,6 +1,5 @@
 use actix_web::{HttpRequest, Json};
-use rita_common::usage_tracker::handle_usage_data;
-use rita_common::usage_tracker::GetUsage;
+use rita_common::usage_tracker::get_usage_data;
 use rita_common::usage_tracker::UsageHour;
 use rita_common::usage_tracker::UsageType;
 use std::collections::VecDeque;
@@ -8,15 +7,11 @@ use std::collections::VecDeque;
 pub fn get_client_usage(_req: HttpRequest) -> Json<VecDeque<UsageHour>> {
     trace!("/usage/client hit");
 
-    Json(handle_usage_data(GetUsage {
-        kind: UsageType::Client,
-    }))
+    Json(get_usage_data(UsageType::Client))
 }
 
 pub fn get_relay_usage(_req: HttpRequest) -> Json<VecDeque<UsageHour>> {
     trace!("/usage/relay hit");
 
-    Json(handle_usage_data(GetUsage {
-        kind: UsageType::Relay,
-    }))
+    Json(get_usage_data(UsageType::Relay))
 }

--- a/rita_common/src/dashboard/usage.rs
+++ b/rita_common/src/dashboard/usage.rs
@@ -1,11 +1,9 @@
-use crate::usage_tracker::handle_get_payments_data;
-use crate::usage_tracker::GetPayments;
-use crate::usage_tracker::PaymentHour;
+use crate::usage_tracker::{get_payments_data, PaymentHour};
 use ::actix_web::{HttpRequest, Json};
 use std::collections::VecDeque;
 
 pub fn get_payments(_req: HttpRequest) -> Json<VecDeque<PaymentHour>> {
     trace!("/usage/relay hit");
 
-    Json(handle_get_payments_data(GetPayments {}))
+    Json(get_payments_data())
 }


### PR DESCRIPTION
This patch is a general cleanup of the usage tracker. The usage tracker
had left over cruft from two different migrations, one to async/await
and the on disk migrations from flatfile storage to compressed storage
plus the rename of the misspelled internal struct.

The combined cruft of these migrations resulted in a very simple error.
previously handle payments was called periodicly by Actix using functions,
as a two part migration payments would be queued onto the payments queue
when sent from an async/await using payments function and then dequeued
when an old futures payment function was called.

Since this file was totally updated to async/await the intermediary call
and the queue where no longer needed but where still being used.
Preventing payment data from ever reaching the disk or the user.

Another issue that became apparent is that json is a rather memory
hungry format and on my test glb1300 the combined payment history for
the clatskanie gateway would cause Rita to be killed by the OOM just
loading the data.

This patch includes a partial fix that takes advantage of streaming
reads and writes to load the data. But that is not enough to allow
returning the data as json from the request endpoint. In order to
mitigate this problem I'm reducing the maximum entries significnatly
for transactions.