### PR TITLE
migrating network_monitor to async/await

### DIFF
--- a/rita_client/src/dashboard/neighbors.rs
+++ b/rita_client/src/dashboard/neighbors.rs
@@ -10,7 +10,7 @@ use babel_monitor_legacy::start_connection_legacy;
 use futures01::Future;
 use num256::{Int256, Uint256};
 use rita_common::debt_keeper::{dump, NodeDebtData};
-use rita_common::network_monitor::{GetStats, IfaceStats, NetworkMonitor, Stats};
+use rita_common::network_monitor::{get_stats, IfaceStats, Stats};
 use rita_common::tunnel_manager::{GetNeighbors, Neighbor, TunnelManager};
 use std::collections::HashMap;
 
@@ -82,20 +82,13 @@ pub fn get_neighbor_info(
                                     .from_err()
                                     .and_then(|(_stream, routes)| {
                                         let route_table_sample = routes;
-
-                                        NetworkMonitor::from_registry()
-                                            .send(GetStats {})
-                                            .from_err()
-                                            .and_then(|stats| {
-                                                let stats = stats.unwrap();
-                                                let output = generate_neighbors_list(
-                                                    stats,
-                                                    route_table_sample,
-                                                    combined_list,
-                                                );
-
-                                                Ok(Json(output))
-                                            })
+                                        let stats = get_stats();
+                                        let output = generate_neighbors_list(
+                                            stats,
+                                            route_table_sample,
+                                            combined_list,
+                                        );
+                                        Ok(Json(output))
                                     })
                                     .responder()
                             })

--- a/rita_common/src/rita_loop/fast_loop.rs
+++ b/rita_common/src/rita_loop/fast_loop.rs
@@ -1,8 +1,8 @@
 use crate::blockchain_oracle::update as BlockchainOracleUpdate;
 use crate::debt_keeper::send_debt_update;
 use crate::eth_compatible_withdraw;
+use crate::network_monitor::update_network_info;
 use crate::network_monitor::NetworkInfo as NetworkMonitorTick;
-use crate::network_monitor::NetworkMonitor;
 use crate::payment_controller::tick_payment_controller;
 use crate::payment_validator::validate;
 use crate::peer_listener::get_peers;
@@ -155,13 +155,11 @@ impl Handler<Tick> for RitaFastLoop {
                                         parse_interfaces_legacy(stream).and_then(
                                             move |(_stream, babel_interfaces)| {
                                                 trace!("Sending network monitor tick");
-                                                NetworkMonitor::from_registry().do_send(
-                                                    NetworkMonitorTick {
-                                                        babel_neighbors,
-                                                        babel_routes,
-                                                        rita_neighbors,
-                                                    },
-                                                );
+                                                update_network_info(NetworkMonitorTick {
+                                                    babel_neighbors,
+                                                    babel_routes,
+                                                    rita_neighbors,
+                                                });
 
                                                 trace!("Sending tunnel GC");
                                                 TunnelManager::from_registry().do_send(TriggerGc {

--- a/rita_common/src/tunnel_manager/shaping.rs
+++ b/rita_common/src/tunnel_manager/shaping.rs
@@ -1,16 +1,25 @@
 use super::TunnelManager;
 use crate::KI;
-use actix::{Context, Handler, Message};
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::RwLock;
 
-lazy_static! {
-    static ref RESET_FLAG: AtomicBool = AtomicBool::new(false);
+/// contains the state for the shaper
+#[derive(Debug, Default)]
+struct Shaper {
+    reset_flag: bool,
+    to_shape: Vec<ShapingAdjust>,
 }
 
-#[allow(dead_code)]
+lazy_static! {
+    static ref SHAPER: Arc<RwLock<Shaper>> = Arc::new(RwLock::new(Shaper::default()));
+}
+
 pub fn flag_reset_shaper() {
-    RESET_FLAG.store(true, Ordering::Relaxed)
+    SHAPER.write().unwrap().reset_flag = true;
+}
+
+pub fn set_to_shape(input: Vec<ShapingAdjust>) {
+    SHAPER.write().unwrap().to_shape = input;
 }
 
 pub struct ShapeMany {
@@ -18,89 +27,84 @@ pub struct ShapeMany {
 }
 
 /// Message sent by network monitor when it determines that an iface is bloated
+#[derive(Debug)]
 pub struct ShapingAdjust {
     pub iface: String,
     pub action: ShapingAdjustAction,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum ShapingAdjustAction {
     IncreaseSpeed,
     ReduceSpeed,
 }
 
-impl Message for ShapeMany {
-    type Result = ();
-}
+pub fn handle_shaping(tunnel_manager: &mut TunnelManager) {
+    let network_settings = settings::get_rita_common().network;
+    let minimum_bandwidth_limit = network_settings.shaper_settings.min_speed;
+    let starting_bandwidth_limit = network_settings.shaper_settings.max_speed;
+    let bandwidth_limit_enabled = network_settings.shaper_settings.enabled;
 
-impl Handler<ShapeMany> for TunnelManager {
-    type Result = ();
+    let mut shaper = SHAPER.write().unwrap();
 
-    fn handle(&mut self, msg: ShapeMany, _: &mut Context<Self>) -> Self::Result {
-        let network_settings = settings::get_rita_common().network;
-        let minimum_bandwidth_limit = network_settings.shaper_settings.min_speed;
-        let starting_bandwidth_limit = network_settings.shaper_settings.max_speed;
-        let bandwidth_limit_enabled = network_settings.shaper_settings.enabled;
-
-        // removes shaping without requiring a restart if the flag is set or
-        // if it's set in the settings
-        if !bandwidth_limit_enabled || RESET_FLAG.load(Ordering::Relaxed) {
-            for (_id, tunnel_list) in self.tunnels.iter_mut() {
-                for tunnel in tunnel_list {
-                    if tunnel.speed_limit != None {
-                        set_shaping_or_error(&tunnel.iface_name, None);
-                        tunnel.speed_limit = None;
-                    }
+    // removes shaping without requiring a restart if the flag is set or
+    // if it's set in the settings
+    if !bandwidth_limit_enabled || shaper.reset_flag {
+        for (_id, tunnel_list) in tunnel_manager.tunnels.iter_mut() {
+            for tunnel in tunnel_list {
+                if tunnel.speed_limit != None {
+                    set_shaping_or_error(&tunnel.iface_name, None);
+                    tunnel.speed_limit = None;
                 }
             }
-            RESET_FLAG.store(false, Ordering::Relaxed);
-            return;
         }
+        shaper.reset_flag = false;
+        return;
+    }
 
-        for shaping_command in msg.to_shape {
-            let action = shaping_command.action;
-            let iface = shaping_command.iface;
-            for (id, tunnel_list) in self.tunnels.iter_mut() {
-                for tunnel in tunnel_list {
-                    if tunnel.iface_name == iface {
-                        match (tunnel.speed_limit, action) {
-                            // nothing to do in this case
-                            (None, ShapingAdjustAction::IncreaseSpeed) => {}
-                            // start at the starting limit
-                            (None, ShapingAdjustAction::ReduceSpeed) => {
-                                tunnel.speed_limit = Some(starting_bandwidth_limit);
-                                set_shaping_or_error(&iface, Some(starting_bandwidth_limit))
-                            }
-                            // after that cut the value by 20% each time
-                            (Some(val), ShapingAdjustAction::ReduceSpeed) => {
-                                let new_val = (val as f32 * 0.8f32) as usize;
-                                if new_val < minimum_bandwidth_limit {
-                                    error!("Interface {} for peer {} is showing bloat but we can't reduce it's bandwidth any further. Current value {}", iface, id.wg_public_key, val);
-                                } else {
-                                    info!(
+    for shaping_command in &shaper.to_shape {
+        let action = shaping_command.action;
+        let iface = &shaping_command.iface;
+        for (id, tunnel_list) in tunnel_manager.tunnels.iter_mut() {
+            for tunnel in tunnel_list {
+                if &tunnel.iface_name == iface {
+                    match (tunnel.speed_limit, action) {
+                        // nothing to do in this case
+                        (None, ShapingAdjustAction::IncreaseSpeed) => {}
+                        // start at the starting limit
+                        (None, ShapingAdjustAction::ReduceSpeed) => {
+                            tunnel.speed_limit = Some(starting_bandwidth_limit);
+                            set_shaping_or_error(iface, Some(starting_bandwidth_limit))
+                        }
+                        // after that cut the value by 20% each time
+                        (Some(val), ShapingAdjustAction::ReduceSpeed) => {
+                            let new_val = (val as f32 * 0.8f32) as usize;
+                            if new_val < minimum_bandwidth_limit {
+                                error!("Interface {} for peer {} is showing bloat but we can't reduce it's bandwidth any further. Current value {}", iface, id.wg_public_key, val);
+                            } else {
+                                info!(
                                     "Interface {} for peer {} is showing bloat new speed value {}",
                                     iface, id.wg_public_key, new_val
                                 );
-                                    set_shaping_or_error(&iface, Some(new_val));
-                                    tunnel.speed_limit = Some(new_val);
-                                }
+                                set_shaping_or_error(iface, Some(new_val));
+                                tunnel.speed_limit = Some(new_val);
                             }
-                            // increase the value by 5% until we reach the starting value
-                            (Some(val), ShapingAdjustAction::IncreaseSpeed) => {
-                                let new_val = increase_speed(val);
-                                if new_val < starting_bandwidth_limit {
-                                    info!(
-                                    "Interface {} for peer {} has not shown bloat new speed value {}",
-                                    iface, id.wg_public_key, new_val
-                                    );
-                                    set_shaping_or_error(&iface, Some(new_val));
-                                    tunnel.speed_limit = Some(new_val);
-                                } else {
-                                    info!(
-                                        "Can not increase on Interface {} for peer {}",
-                                        iface, id.wg_public_key
-                                    );
-                                }
+                        }
+                        // increase the value by 5% until we reach the starting value
+                        (Some(val), ShapingAdjustAction::IncreaseSpeed) => {
+                            let new_val = increase_speed(val);
+                            if new_val < starting_bandwidth_limit {
+                                info!(
+                                "Interface {} for peer {} has not shown bloat new speed value {}",
+                                iface, id.wg_public_key, new_val
+                                );
+                                set_shaping_or_error(iface, Some(new_val));
+                                tunnel.speed_limit = Some(new_val);
+                            } else {
+                                info!(
+                                    "Can not increase on Interface {} for peer {}",
+                                    iface, id.wg_public_key
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
Converted network_monitor to async/await: actix impls removed and replaced with lazy_static to store data for cross thread getters