### PR TITLE
Modernizing usage tracker, replacing serde_json with bincode

### DIFF
--- a/rita_common/src/error.rs
+++ b/rita_common/src/error.rs
@@ -11,6 +11,7 @@ use babel_monitor::BabelMonitorError;
 use compressed_log::builder::LoggerError;
 use log::SetLoggerError;
 use settings::SettingsError;
+use std::boxed::Box;
 
 #[derive(Debug)]
 pub enum RitaCommonError {
@@ -30,6 +31,7 @@ pub enum RitaCommonError {
     BabelMonitorError(BabelMonitorError),
     SysTimeError(SystemTimeError),
     OldSendRequestError(String),
+    BincodeError(Box<bincode::ErrorKind>),
 }
 
 impl From<LoggerError> for RitaCommonError {
@@ -72,6 +74,11 @@ impl From<SystemTimeError> for RitaCommonError {
         RitaCommonError::SysTimeError(error)
     }
 }
+impl From<std::boxed::Box<bincode::ErrorKind>> for RitaCommonError {
+    fn from(error: std::boxed::Box<bincode::ErrorKind>) -> Self {
+        RitaCommonError::BincodeError(error)
+    }
+}
 
 impl ResponseError for RitaCommonError {}
 
@@ -104,6 +111,7 @@ impl Display for RitaCommonError {
             RitaCommonError::BabelMonitorError(a) => write!(f, "{}", a,),
             RitaCommonError::SysTimeError(a) => write!(f, "{}", a,),
             RitaCommonError::OldSendRequestError(e) => write!(f, "{}", e),
+            RitaCommonError::BincodeError(e) => write!(f, "{}", e),
 
         }
     }

--- a/settings/src/network.rs
+++ b/settings/src/network.rs
@@ -16,7 +16,7 @@ fn default_metric_factor() -> u32 {
 }
 
 fn default_usage_tracker_file() -> String {
-    "/etc/rita-usage-tracker.json".to_string()
+    "/etc/rita-usage-tracker.bincode".to_string()
 }
 
 fn default_shaper_settings() -> ShaperSettings {


### PR DESCRIPTION
- load_from_disk() now looks for the updated .bincode usage tracker file to read from, and if only the old .json is found reads from that then resaves with bincode and deletes the .json file
- save() now uses bincode serialization to a .bincode file
- added unit tests