### PR TITLE
restore min fee configurability

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -391,6 +391,9 @@ pub enum OperatorAction {
     /// this has it's own logic in the operator tools that will later be removed for the logic
     /// you see in Althea_rs
     ChangeOperatorAddress { new_address: Option<Address> },
+    /// Sets the min gas value to the provided value, primarily intended for use on xDai where
+    /// the validators set a minimum gas price as a group without warning
+    SetMinGas { new_min_gas: Uint256 },
 }
 
 /// Operator update that we get from the operator server during our checkin

--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -272,6 +272,13 @@ async fn checkin() {
             info!("Got outdated command ChangeReleaseFeedAndUpdate")
         }
         Some(OperatorAction::UpdateNow) => info!("Got outdated command UpdateNow"),
+        Some(OperatorAction::SetMinGas { new_min_gas }) => {
+            info!(
+                "Updated min gas from {} to {}",
+                rita_client.payment.min_gas, new_min_gas
+            );
+            rita_client.payment.min_gas = new_min_gas;
+        }
         None => {}
     }
     network.shaper_settings = new_settings.shaper_settings;

--- a/rita_common/src/blockchain_oracle/mod.rs
+++ b/rita_common/src/blockchain_oracle/mod.rs
@@ -67,10 +67,6 @@ const CLOSE_THRESH_MULT: i32 = 10;
 /// in the rita_common fast loop
 pub const ORACLE_TIMEOUT: Duration = FAST_LOOP_TIMEOUT;
 
-/// Minimum gas price. When gas is below this, we set gasprice to this value, which is then used to
-/// calculate pay and close thresh
-pub const MIN_GAS: u32 = 1_000_000_000;
-
 lazy_static! {
     /// This lazy static hold info about gas, thresholds and payment info for the router
     static ref ORACLE: Arc<RwLock<BlockchainOracle>> =
@@ -280,6 +276,9 @@ fn update_gas_price(
     let oracle_gas_price: Uint256;
     let mut oracle_pay_thresh: Int256 = 0u128.into();
     let oracle_close_thresh: Int256;
+    // Minimum gas price. When gas is below this, we set gasprice to this value, which is then used to
+    // calculate pay and close thresh
+    let min_gas = payment_settings.min_gas.clone();
 
     let value = new_gas_price;
     info!(
@@ -291,7 +290,6 @@ fn update_gas_price(
     // in the worst case compared to averaging
     oracle_gas_price = value;
 
-    let min_gas: Uint256 = MIN_GAS.into();
     let oracle_gas_price = if oracle_gas_price < min_gas {
         info!("gas price is low setting to! {}", min_gas);
         min_gas

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -514,7 +514,6 @@ impl DebtKeeper {
         let payment_settings = settings::get_rita_common().payment;
         let close_threshold = get_oracle_close_thresh();
         let pay_threshold = get_oracle_pay_thresh();
-        let fudge_factor = payment_settings.fudge_factor;
         let debt_limit_enabled = payment_settings.debt_limit_enabled;
         let apply_incoming_credit_immediately = payment_settings.apply_incoming_credit_immediately;
 
@@ -553,16 +552,11 @@ impl DebtKeeper {
                 Ok(DebtAction::SuspendTunnel)
             }
             (false, true, false) => {
-                let mut to_pay: Uint256 = debt_data.debt.to_uint256().ok_or_else(|| {
+                let to_pay: Uint256 = debt_data.debt.to_uint256().ok_or_else(|| {
                     RitaCommonError::ConversionError(
                         "Unable to convert debt data into unsigned 256 bit integer".to_string(),
                     )
                 })?;
-                // overpay by the fudge_factor to encourage convergence, this is currently set
-                // to zero in all production networks, so maybe it can be removed
-                if fudge_factor != 0 {
-                    to_pay = to_pay.clone() + (to_pay / fudge_factor.into());
-                }
 
                 debt_data.payment_in_flight = true;
                 debt_data.payment_in_flight_start = Some(Instant::now());

--- a/settings/src/payment.rs
+++ b/settings/src/payment.rs
@@ -71,6 +71,10 @@ fn default_forgive_on_reboot() -> bool {
     true
 }
 
+fn default_min_gas() -> Uint256 {
+    2_000_000_000u128.into()
+}
+
 /// This struct is used by both rita and rita_exit to configure the dummy payment controller and
 /// debt keeper
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -150,6 +154,10 @@ pub struct PaymentSettings {
     /// if we forgive all debts on reboot
     #[serde(default = "default_forgive_on_reboot")]
     pub forgive_on_reboot: bool,
+    /// We will not send a tx with a gas price lower than this, useful for pre eip-1559 networks and
+    /// post-eip1599 networks that do not respect min-fee
+    #[serde(default = "default_min_gas")]
+    pub min_gas: Uint256,
 }
 
 impl Default for PaymentSettings {
@@ -176,6 +184,7 @@ impl Default for PaymentSettings {
             simulated_transaction_fee_address: default_simulated_transaction_fee_address(),
             simulated_transaction_fee: default_simulated_transaction_fee(),
             forgive_on_reboot: default_forgive_on_reboot(),
+            min_gas: default_min_gas(),
         }
     }
 }

--- a/settings/src/payment.rs
+++ b/settings/src/payment.rs
@@ -18,10 +18,6 @@ fn default_dynamic_fee_multiplier() -> u32 {
     XDAI_FEE_MULTIPLIER
 }
 
-fn default_fudge_factor() -> u8 {
-    0
-}
-
 fn default_free_tier_throughput() -> u32 {
     1000
 }
@@ -127,13 +123,6 @@ pub struct PaymentSettings {
     pub debts_file: String,
     #[serde(default = "default_bridge_enabled")]
     pub bridge_enabled: bool,
-    /// A value used to divide and add to a payment, essentailly a cheating tool for
-    /// payment convergence. Computed as payment_amount + (payment_amount/fudge_factor)
-    /// so a factor of 100 would be a 1% overpayment this helps cover up errors in accounting
-    /// by pushing the system into overpayment and therefore convergence. Currently not used
-    /// probably should be axed as cruft
-    #[serde(default = "default_fudge_factor")]
-    pub fudge_factor: u8,
     /// See where this is referenced in debt keeper, this option is on for exits and off everywhere
     /// else. The problem requiring it's creation is that the Exit has it's debts observed by clients
     /// who pay when it exceeds the pay threshold. Relays have no such issue and their internal balances
@@ -181,7 +170,6 @@ impl Default for PaymentSettings {
             withdraw_chain: default_system_chain(),
             debts_file: default_debts_file(),
             bridge_enabled: default_bridge_enabled(),
-            fudge_factor: 0u8,
             debt_limit_enabled: default_debt_limit_enabled(),
             apply_incoming_credit_immediately: default_apply_incoming_credit(),
             bridge_addresses: default_bridge_addresses(),


### PR DESCRIPTION
Post EIP1559 on xdai (gnosis chain) I believed the min gas setting could be safely removed,
after all with the implementation of EIP1559 it was no longer needed to
have the validators conspire and set a minimum gas fee there was now a
defined value to use.

This ended up being wrong it seems, as the EIP1559 block base fee is
based on how full the block is, and since xdai blocks are essentially
always empty the value is extremely low, well below one gwei. Instead of
modifying the EIP1559 consensus parameters the xdai validators seem to
have instead just re-implemented the same min fee logic as before but
now with a higher value.

What this patch does is restore the min_fee setting and provides an
operator action for updating it as I suspect we will be doing this
often.