### PR TITLE
Completely Migrated Rita Client to asnyc await. Removed the following…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,8 +3216,6 @@ name = "rita_client"
 version = "0.19.1"
 dependencies = [
  "actix 0.12.0",
- "actix 0.7.11",
- "actix-web 0.7.19",
  "actix-web 4.0.0-beta.20",
  "actix-web-httpauth 0.6.0-beta.7",
  "althea_kernel_interface",
@@ -3226,11 +3224,9 @@ dependencies = [
  "arrayvec 0.7.2",
  "awc",
  "babel_monitor",
- "babel_monitor_legacy",
  "clarity",
  "clu",
  "compressed_log",
- "futures 0.1.31",
  "hex-literal",
  "ipnetwork 0.18.0",
  "lazy_static",
@@ -3247,9 +3243,6 @@ dependencies = [
  "settings",
  "sha3",
  "sodiumoxide",
- "tokio 0.1.22",
- "tokio-codec",
- "tokio-io",
  "web30",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,9 +3251,7 @@ name = "rita_common"
 version = "0.19.1"
 dependencies = [
  "actix 0.12.0",
- "actix 0.7.11",
  "actix-service",
- "actix-web 0.7.19",
  "actix-web 4.0.0-beta.20",
  "actix-web-httpauth 0.6.0-beta.7",
  "althea_kernel_interface",
@@ -3262,7 +3260,6 @@ dependencies = [
  "auto-bridge",
  "awc",
  "babel_monitor",
- "babel_monitor_legacy",
  "bincode",
  "byteorder",
  "bytes 1.1.0",
@@ -3285,7 +3282,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "settings",
- "tokio 0.1.22",
  "web30",
 ]
 

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -34,8 +34,8 @@ use rita_client::wait_for_settings;
 use rita_client::Args;
 use rita_common::debt_keeper::save_debt_on_shutdown;
 use rita_common::logging::enable_remote_logging;
-use rita_common::rita_loop::check_rita_common_actors;
 use rita_common::rita_loop::start_core_rita_endpoints;
+use rita_common::rita_loop::start_rita_common_loops;
 use rita_common::usage_tracker::save_usage_on_shutdown;
 use rita_common::utils::env_vars_contains;
 use settings::client::RitaClientSettings;
@@ -137,7 +137,7 @@ fn main() {
 
     let system = actix::System::new(format!("main {:?}", settings.network.mesh_ip));
 
-    check_rita_common_actors();
+    start_rita_common_loops();
     start_rita_client_loops();
     start_core_rita_endpoints(4);
     start_rita_client_endpoints(1);

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -27,9 +27,9 @@ use althea_kernel_interface::LinuxCommandRunner;
 use docopt::Docopt;
 use rita_client::dashboard::start_client_dashboard;
 use rita_client::get_client_usage;
-use rita_client::rita_loop::check_rita_client_actors;
 use rita_client::rita_loop::start_antenna_forwarder;
 use rita_client::rita_loop::start_rita_client_endpoints;
+use rita_client::rita_loop::start_rita_client_loops;
 use rita_client::wait_for_settings;
 use rita_client::Args;
 use rita_common::debt_keeper::save_debt_on_shutdown;
@@ -138,7 +138,7 @@ fn main() {
     let system = actix::System::new(format!("main {:?}", settings.network.mesh_ip));
 
     check_rita_common_actors();
-    check_rita_client_actors();
+    start_rita_client_loops();
     start_core_rita_endpoints(4);
     start_rita_client_endpoints(1);
     start_client_dashboard(settings.network.rita_dashboard_port);

--- a/rita_bin/src/exit.rs
+++ b/rita_bin/src/exit.rs
@@ -25,8 +25,8 @@ extern crate log;
 use docopt::Docopt;
 use rita_common::debt_keeper::save_debt_on_shutdown;
 use rita_common::logging::enable_remote_logging;
-use rita_common::rita_loop::check_rita_common_actors;
 use rita_common::rita_loop::start_core_rita_endpoints;
+use rita_common::rita_loop::start_rita_common_loops;
 use rita_common::usage_tracker::save_usage_on_shutdown;
 use rita_common::utils::env_vars_contains;
 use rita_exit::database::sms::send_admin_notification_sms;
@@ -123,7 +123,7 @@ fn main() {
 
     let system = actix::System::new(format!("main {:?}", settings.network.mesh_ip));
 
-    check_rita_common_actors();
+    start_rita_common_loops();
     check_rita_exit_actors();
     start_rita_exit_loop();
     let workers = settings.workers;

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -15,7 +15,6 @@ serde_json = "1.0"
 lazy_static = "1.4"
 hex-literal = "0.3"
 rita_common = { path = "../rita_common" }
-futures01 = { package = "futures", version = "0.1"}
 log = { version = "0.4", features = ["release_max_level_info"] }
 althea_types = { path = "../althea_types" }
 althea_kernel_interface = { path = "../althea_kernel_interface" }
@@ -26,19 +25,13 @@ lettre = "0.9"
 lettre_email = "0.9"
 phonenumber = "0.3"
 babel_monitor = { path = "../babel_monitor" }
-babel_monitor_legacy = {path = "../babel_monitor_legacy"}
 arrayvec = {version= "0.7", features = ["serde"]}
-tokio = "0.1"
-tokio-io = "0.1"
-tokio-codec = "0.1"
 sodiumoxide = "0.2"
 clu = { path = "../clu" }
 web30 = "0.18"
-actix = "0.7"
 awc = "3.0.0-beta.18"
 ipnetwork = "0.18"
 actix-async = {package="actix", version = "0.12"}
-actix-web = { version = "0.7", default_features = false, features= ["ssl"] }
 actix-web-async = { package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"]}
 actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0-beta.7"}
 clarity = "0.5"

--- a/rita_client/src/error.rs
+++ b/rita_client/src/error.rs
@@ -6,9 +6,6 @@ use std::{
     string::FromUtf8Error,
 };
 
-use actix::MailboxError;
-use actix_web::client::SendRequestError as OldSendRequestError;
-use actix_web::error::JsonPayloadError as OldJsonPayloadError;
 use althea_kernel_interface::KernelInterfaceError;
 use awc::error::{JsonPayloadError, SendRequestError};
 use babel_monitor::BabelMonitorError;
@@ -76,19 +73,9 @@ impl From<SendRequestError> for RitaClientError {
         RitaClientError::TimeoutError(error.to_string())
     }
 }
-impl From<OldSendRequestError> for RitaClientError {
-    fn from(error: OldSendRequestError) -> Self {
-        RitaClientError::RitaCommonError(RitaCommonError::OldSendRequestError(error.to_string()))
-    }
-}
 impl From<JsonPayloadError> for RitaClientError {
     fn from(error: JsonPayloadError) -> Self {
         RitaClientError::JsonPayloadError(error.to_string())
-    }
-}
-impl From<OldJsonPayloadError> for RitaClientError {
-    fn from(error: OldJsonPayloadError) -> Self {
-        RitaClientError::OldJsonPayloadError(error.to_string())
     }
 }
 impl From<serde_json::Error> for RitaClientError {
@@ -109,11 +96,6 @@ impl From<RitaCommonError> for RitaClientError {
 impl From<BabelMonitorError> for RitaClientError {
     fn from(error: BabelMonitorError) -> Self {
         RitaClientError::RitaCommonError(RitaCommonError::BabelMonitorError(error))
-    }
-}
-impl From<MailboxError> for RitaClientError {
-    fn from(error: MailboxError) -> Self {
-        RitaClientError::RitaCommonError(RitaCommonError::MailboxError(error))
     }
 }
 impl From<ParseIntError> for RitaClientError {
@@ -166,5 +148,3 @@ impl Display for RitaClientError {
 }
 
 impl Error for RitaClientError {}
-
-impl actix_web::ResponseError for RitaClientError {}

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-actix = "0.7"
 rand = "0.8.0"
 ipnetwork = "0.18"
 serde_derive = "1.0"
@@ -28,19 +27,16 @@ futures = { version = "0.3", features = ["compat"] }
 num256 = "0.3"
 num-traits="0.2"
 futures01 = { package = "futures", version = "0.1"}
-tokio = "0.1"
 bincode = "1.3"
 serde_cbor = "0.11"
 lazy_static = "1.4"
 althea_kernel_interface = { path = "../althea_kernel_interface" }
 actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0-beta.7"}
-actix-web = { version = "0.7", default_features = false, features= ["ssl"] }
 actix-web-async = { package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"]}
 awc = {version = "3.0.0-beta.8", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}
 actix-service = "2.0.2"
 web30 = "0.18"
 althea_types = { path = "../althea_types" }
-babel_monitor_legacy = {path = "../babel_monitor_legacy"} 
 
 [dependencies.regex]
 version = "1.4"

--- a/rita_common/src/dashboard/mod.rs
+++ b/rita_common/src/dashboard/mod.rs
@@ -2,9 +2,6 @@
 //! management and automation. They exist on port 4877 by default and should be firewalled
 //! from the outside world for obvious security reasons.
 
-use actix::prelude::*;
-use actix::registry::SystemService;
-
 pub mod babel;
 pub mod debts;
 pub mod development;
@@ -15,17 +12,3 @@ pub mod token_bridge;
 pub mod usage;
 pub mod wallet;
 pub mod wg_key;
-
-#[derive(Default)]
-pub struct Dashboard;
-
-impl Actor for Dashboard {
-    type Context = Context<Self>;
-}
-
-impl Supervised for Dashboard {}
-impl SystemService for Dashboard {
-    fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        info!("Dashboard started");
-    }
-}

--- a/rita_common/src/error.rs
+++ b/rita_common/src/error.rs
@@ -4,8 +4,6 @@ use std::{
     time::SystemTimeError,
 };
 
-use actix::MailboxError;
-use actix_web::ResponseError;
 use althea_kernel_interface::KernelInterfaceError;
 use babel_monitor::BabelMonitorError;
 use compressed_log::builder::LoggerError;
@@ -24,7 +22,6 @@ pub enum RitaCommonError {
     SettingsError(SettingsError),
     CapacityError(String),
     MiscStringError(String),
-    MailboxError(actix::MailboxError),
     KernelInterfaceError(KernelInterfaceError),
     StdError(std::io::Error),
     Lowest20Error(usize),
@@ -47,11 +44,6 @@ impl From<SetLoggerError> for RitaCommonError {
 impl From<SettingsError> for RitaCommonError {
     fn from(error: SettingsError) -> Self {
         RitaCommonError::SettingsError(error)
-    }
-}
-impl From<MailboxError> for RitaCommonError {
-    fn from(error: MailboxError) -> Self {
-        RitaCommonError::MailboxError(error)
     }
 }
 impl From<KernelInterfaceError> for RitaCommonError {
@@ -80,8 +72,6 @@ impl From<std::boxed::Box<bincode::ErrorKind>> for RitaCommonError {
     }
 }
 
-impl ResponseError for RitaCommonError {}
-
 impl Display for RitaCommonError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
@@ -102,7 +92,6 @@ impl Display for RitaCommonError {
                 f, "Capacity Error: {}", a,
             ),
             RitaCommonError::MiscStringError(a) => write!(f, "{}", a,),
-            RitaCommonError::MailboxError(a) => write!(f, "{}", a,),
             RitaCommonError::KernelInterfaceError(a) => write!(f, "{}", a,),
             RitaCommonError::StdError(a) => write!(f, "{}", a,),
             RitaCommonError::Lowest20Error(a) => write!(

--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -13,7 +13,6 @@ use crate::rita_loop::fast_loop::FAST_LOOP_TIMEOUT;
 use crate::rita_loop::get_web3_server;
 use crate::usage_tracker::update_payments;
 
-use actix::System;
 use althea_types::PaymentTx;
 use num256::Uint256;
 use web30::client::Web3;
@@ -197,9 +196,9 @@ pub async fn validate() {
                 error!("{}", msg);
                 // drop the lock to prevent poisoning if we don't manage to crash
                 drop(history);
-                // get the non-async actix system and try to shut down the whole process
-                let system = System::current();
-                system.stop_with_code(121);
+
+                let sys = actix_async::System::current();
+                sys.stop_with_code(121);
                 // this satisfies the borrow checker to let us drop history so that if we
                 // fail to get the current actix system we don't poison the lock fatally
                 return;

--- a/rita_common/src/rita_loop/fast_loop.rs
+++ b/rita_common/src/rita_loop/fast_loop.rs
@@ -15,20 +15,12 @@ use crate::tunnel_manager::tm_contact_peers;
 use crate::tunnel_manager::tm_get_neighbors;
 use crate::tunnel_manager::PeersToContact;
 use crate::update_neighbor_status;
-use crate::RitaCommonError;
-use actix::{
-    Actor, ActorContext, Addr, Arbiter, AsyncContext, Context, Handler, Message, Supervised,
-    System, SystemService,
-};
+
 use actix_async::System as AsyncSystem;
 use babel_monitor::open_babel_stream;
 use babel_monitor::parse_interfaces;
 use babel_monitor::parse_neighs;
 use babel_monitor::parse_routes;
-use babel_monitor_legacy::open_babel_stream_legacy;
-use babel_monitor_legacy::parse_routes_legacy;
-use babel_monitor_legacy::start_connection_legacy;
-use futures01::Future;
 
 use std::thread;
 use std::time::{Duration, Instant};
@@ -44,140 +36,11 @@ pub const FAST_LOOP_TIMEOUT: Duration = Duration::from_secs(4);
 pub const TUNNEL_TIMEOUT: Duration = Duration::from_secs(900);
 pub const TUNNEL_HANDSHAKE_TIMEOUT: Duration = TUNNEL_TIMEOUT;
 
-#[derive(Default)]
-pub struct RitaFastLoop {}
-
-impl Actor for RitaFastLoop {
-    type Context = Context<Self>;
-
-    fn started(&mut self, ctx: &mut Context<Self>) {
-        trace!("Common rita loop started!");
-
-        ctx.run_interval(FAST_LOOP_SPEED, |_act, ctx| {
-            let addr: Addr<Self> = ctx.address();
-            addr.do_send(Tick);
-        });
-    }
-}
-
-impl SystemService for RitaFastLoop {}
-impl Supervised for RitaFastLoop {
-    fn restarting(&mut self, _ctx: &mut Context<RitaFastLoop>) {
-        error!("Rita Common loop actor died! recovering!");
-    }
-}
-
-/// Used to test actor respawning
-pub struct Crash;
-
-impl Message for Crash {
-    type Result = Result<(), RitaCommonError>;
-}
-
-impl Handler<Crash> for RitaFastLoop {
-    type Result = Result<(), RitaCommonError>;
-    fn handle(&mut self, _: Crash, ctx: &mut Context<Self>) -> Self::Result {
-        ctx.stop();
-        Ok(())
-    }
-}
-
-pub struct Tick;
-
-impl Message for Tick {
-    type Result = Result<(), RitaCommonError>;
-}
-
-impl Handler<Tick> for RitaFastLoop {
-    type Result = Result<(), RitaCommonError>;
-    fn handle(&mut self, _: Tick, _ctx: &mut Context<Self>) -> Self::Result {
-        let babel_port = settings::get_rita_common().network.babel_port;
-        trace!("Common tick!");
-
-        let start = Instant::now();
-
-        let res = tm_get_neighbors();
-        trace!("Currently open tunnels: {:?}", res);
-        let neighbors = res;
-        let neigh = Instant::now();
-        info!(
-            "GetNeighbors completed in {}s {}ms",
-            start.elapsed().as_secs(),
-            start.elapsed().subsec_millis()
-        );
-
-        //watch neighbors for billing
-        Arbiter::spawn(
-            open_babel_stream_legacy(babel_port)
-                .from_err()
-                .and_then(move |stream| {
-                    start_connection_legacy(stream).and_then(move |stream| {
-                        parse_routes_legacy(stream).and_then(move |routes| {
-                            let _res = watch(routes.1, &neighbors);
-                            info!(
-                                "TrafficWatcher completed in {}s {}ms",
-                                neigh.elapsed().as_secs(),
-                                neigh.elapsed().subsec_millis()
-                            );
-                            Ok(())
-                        })
-                    })
-                })
-                .then(|ret| {
-                    if let Err(e) = ret {
-                        error!("Failed to watch client traffic with {:?}", e)
-                    }
-                    Ok(())
-                }),
-        );
-
-        // Observe the dataplane for status and problems. Tunnel GC checks for specific issues
-        // (tunnels that are installed but not active) and cleans up cruft. We put these together
-        // because both can fail without anything truly bad happening and we get a slight efficiency
-        // bonus running them together (fewer babel socket connections per loop iteration)
-        let rita_neighbors = tm_get_neighbors();
-        if let Ok(mut stream) = open_babel_stream(babel_port, FAST_LOOP_TIMEOUT) {
-            let babel_neighbors = parse_neighs(&mut stream);
-            let babel_interfaces = parse_interfaces(&mut stream);
-            let babel_routes = parse_routes(&mut stream);
-            if let (Ok(babel_neighbors), Ok(babel_routes)) = (babel_neighbors, babel_routes) {
-                trace!("Sending network monitor tick");
-                update_network_info(NetworkMonitorTick {
-                    babel_neighbors,
-                    babel_routes,
-                    rita_neighbors,
-                });
-            }
-
-            if let Ok(babel_interfaces) = babel_interfaces {
-                trace!("Sending tunnel GC");
-                let _res = tm_trigger_gc(TriggerGc {
-                    tunnel_timeout: TUNNEL_TIMEOUT,
-                    tunnel_handshake_timeout: TUNNEL_HANDSHAKE_TIMEOUT,
-                    babel_interfaces,
-                });
-            }
-        }
-
-        // Update debts
-        if let Err(e) = send_debt_update() {
-            warn!("Debt keeper update failed! {:?}", e);
-        }
-
-        update_neighbor_status();
-        handle_shaping();
-
-        Ok(())
-    }
-}
-
 /// Rita fast loop thread spawning function, there are currently two rita fast loops, one that
 /// runs as a thread with async/await support and one that runs as a actor using old futures
 /// slowly things will be migrated into this new sync loop as we move to async/await
 pub fn start_rita_fast_loop() {
     let mut last_restart = Instant::now();
-    // this is a reference to the non-async actix system since this can bring down the whole process
-    let system = System::current();
     // outer thread is a watchdog inner thread is the runner
     thread::spawn(move || {
         // this will always be an error, so it's really just a loop statement
@@ -189,6 +52,72 @@ pub fn start_rita_fast_loop() {
 
                 let runner = AsyncSystem::new();
                 runner.block_on(async move {
+                    let babel_port = settings::get_rita_common().network.babel_port;
+                    trace!("Common tick!");
+
+                    let start = Instant::now();
+
+                    let res = tm_get_neighbors();
+                    trace!("Currently open tunnels: {:?}", res);
+                    let neighbors = res;
+                    let neigh = Instant::now();
+                    info!(
+                        "GetNeighbors completed in {}s {}ms",
+                        start.elapsed().as_secs(),
+                        start.elapsed().subsec_millis()
+                    );
+
+                    if let Ok(mut stream) = open_babel_stream(babel_port, FAST_LOOP_TIMEOUT) {
+                        if let Ok(babel_routes) = parse_routes(&mut stream) {
+                            if let Err(e) = watch(babel_routes, &neighbors) {
+                                error!("Error for Rita common traffic watcher {}", e);
+                            }
+                            info!(
+                                "TrafficWatcher completed in {}s {}ms",
+                                neigh.elapsed().as_secs(),
+                                neigh.elapsed().subsec_millis()
+                            );
+                        }
+                    }
+
+                    // Observe the dataplane for status and problems. Tunnel GC checks for specific issues
+                    // (tunnels that are installed but not active) and cleans up cruft. We put these together
+                    // because both can fail without anything truly bad happening and we get a slight efficiency
+                    // bonus running them together (fewer babel socket connections per loop iteration)
+                    let rita_neighbors = tm_get_neighbors();
+                    if let Ok(mut stream) = open_babel_stream(babel_port, FAST_LOOP_TIMEOUT) {
+                        let babel_neighbors = parse_neighs(&mut stream);
+                        let babel_interfaces = parse_interfaces(&mut stream);
+                        let babel_routes = parse_routes(&mut stream);
+                        if let (Ok(babel_neighbors), Ok(babel_routes)) =
+                            (babel_neighbors, babel_routes)
+                        {
+                            trace!("Sending network monitor tick");
+                            update_network_info(NetworkMonitorTick {
+                                babel_neighbors,
+                                babel_routes,
+                                rita_neighbors,
+                            });
+                        }
+
+                        if let Ok(babel_interfaces) = babel_interfaces {
+                            trace!("Sending tunnel GC");
+                            let _res = tm_trigger_gc(TriggerGc {
+                                tunnel_timeout: TUNNEL_TIMEOUT,
+                                tunnel_handshake_timeout: TUNNEL_HANDSHAKE_TIMEOUT,
+                                babel_interfaces,
+                            });
+                        }
+                    }
+
+                    // Update debts
+                    if let Err(e) = send_debt_update() {
+                        warn!("Debt keeper update failed! {:?}", e);
+                    }
+
+                    update_neighbor_status();
+                    handle_shaping();
+
                     // updating blockchain info often is easier than dealing with edge cases
                     // like out of date nonces or balances, also users really really want fast
                     // balance updates, think very long and very hard before running this more slowly
@@ -217,7 +146,8 @@ pub fn start_rita_fast_loop() {
             error!("Rita common fast loop thread paniced! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(60) {
                 error!("Restarting too quickly, leaving it to auto rescue!");
-                system.stop_with_code(121)
+                let sys = AsyncSystem::current();
+                sys.stop_with_code(121);
             }
             last_restart = Instant::now();
         }
@@ -228,8 +158,6 @@ pub fn start_rita_fast_loop() {
 /// to block the entire loop
 pub fn peer_discovery_loop() {
     let mut last_restart = Instant::now();
-    // this is a reference to the non-async actix system since this can bring down the whole process
-    let system = System::current();
     // outer thread is a watchdog inner thread is the runner
     thread::spawn(move || {
         // this will always be an error, so it's really just a loop statement
@@ -274,7 +202,8 @@ pub fn peer_discovery_loop() {
             );
             if Instant::now() - last_restart < Duration::from_secs(60) {
                 error!("Restarting too quickly, leaving it to auto rescue!");
-                system.stop_with_code(121)
+                let sys = AsyncSystem::current();
+                sys.stop_with_code(121);
             }
             last_restart = Instant::now();
         }

--- a/rita_common/src/rita_loop/mod.rs
+++ b/rita_common/src/rita_loop/mod.rs
@@ -7,7 +7,6 @@
 
 use crate::network_endpoints::*;
 use crate::traffic_watcher::init_traffic_watcher;
-use actix::SystemService;
 use actix_async::System;
 use actix_web_async::{web, App, HttpServer};
 use rand::thread_rng;
@@ -91,9 +90,8 @@ pub fn start_core_rita_endpoints(workers: usize) {
     });
 }
 
-pub fn check_rita_common_actors() {
+pub fn start_rita_common_loops() {
     init_traffic_watcher();
-    assert!(crate::rita_loop::fast_loop::RitaFastLoop::from_registry().connected());
     crate::rita_loop::slow_loop::start_rita_slow_loop();
     crate::rita_loop::fast_loop::start_rita_fast_loop();
     crate::rita_loop::fast_loop::peer_discovery_loop();

--- a/rita_common/src/rita_loop/slow_loop.rs
+++ b/rita_common/src/rita_loop/slow_loop.rs
@@ -1,6 +1,5 @@
 use crate::simulated_txfee_manager::tick_simulated_tx;
 use crate::token_bridge::tick_token_bridge;
-use actix::System;
 use actix_async::System as AsyncSystem;
 use babel_monitor::open_babel_stream;
 use babel_monitor::set_local_fee;
@@ -14,7 +13,6 @@ pub const SLOW_LOOP_SPEED: Duration = Duration::from_secs(60);
 pub const SLOW_LOOP_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub fn start_rita_slow_loop() {
-    let system = System::current();
     let mut last_restart = Instant::now();
     thread::spawn(move || {
         // this will always be an error, so it's really just a loop statement
@@ -50,7 +48,8 @@ pub fn start_rita_slow_loop() {
             error!("Rita common slow loop thread panicked! Respawning {:?}", e);
             if Instant::now() - last_restart < Duration::from_secs(120) {
                 error!("Restarting too quickly, leaving it to auto rescue!");
-                system.stop_with_code(121)
+                let sys = AsyncSystem::current();
+                sys.stop_with_code(121);
             }
             last_restart = Instant::now();
         }

--- a/rita_common/src/usage_tracker/mod.rs
+++ b/rita_common/src/usage_tracker/mod.rs
@@ -4,7 +4,6 @@
 //! the handler updates the storage to reflect the new total. When a user would like to inspect
 //! or graph usage they query an endpoint which will request the data from this module.
 
-use actix::Message;
 use althea_types::Identity;
 use althea_types::PaymentTx;
 use bincode::Error as BincodeError;
@@ -297,10 +296,6 @@ pub struct UpdateUsage {
     pub up: u64,
     pub down: u64,
     pub price: u32,
-}
-
-impl Message for UpdateUsage {
-    type Result = Result<(), RitaCommonError>;
 }
 
 pub fn update_usage_data(msg: UpdateUsage) {


### PR DESCRIPTION
Once All these commits are merged, rita-bin can be migrated and additional crates and files like babel-monitor-legacy and WaitTimeout can be removed