### PR TITLE
Fix to rita exit preventing possible infinite payments from client to…

### DIFF
--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -13,6 +13,7 @@ use crate::rita_loop::fast_loop::FAST_LOOP_TIMEOUT;
 use crate::rita_loop::get_web3_server;
 use crate::usage_tracker::update_payments;
 
+use althea_types::Identity;
 use althea_types::PaymentTx;
 use num256::Uint256;
 use web30::client::Web3;
@@ -89,6 +90,22 @@ impl Default for PaymentValidator {
     fn default() -> PaymentValidator {
         PaymentValidator::new()
     }
+}
+
+/// Function to compute the total amount of all unverified payments
+/// Input: takes in an identity which represents the router we are
+/// going to exclude from the total amount of all unverified payments.
+pub fn calculate_unverified_payments(router: Identity) -> Uint256 {
+    let history = HISTORY.read().unwrap();
+    let payments_to_process = history.unvalidated_transactions.clone();
+    drop(history);
+    let mut total_unverified_payment: Uint256 = Uint256::from(0u32);
+    for iterate in payments_to_process.iter() {
+        if iterate.payment.from == router && iterate.payment.to != router {
+            total_unverified_payment += iterate.payment.amount.clone();
+        }
+    }
+    total_unverified_payment
 }
 
 /// Message to insert transactions into payment validator, once inserted they will remain


### PR DESCRIPTION
… exit

There is an issue within rita client that packet loss could result in an excess
payment since rita client assumes there is no packet loss and will always
pay the amount the exit gives even if the local amount is different.

This combined with how the payments could take a while to verify means that the
client will continually send payments over to the exit which piles ontop
of itself. This code will attempt to subtract the excess and handle this.