### PR TITLE
Increase payment validator timeout

### DIFF
--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -103,7 +103,7 @@ impl dyn KernelInterface {
                 "listen-port",
                 &format!("{}", args.port),
                 "private-key",
-                &args.private_key_path.to_str().unwrap().to_string(),
+                args.private_key_path.to_str().unwrap(),
                 "peer",
                 &format!("{}", args.remote_pub_key),
                 "endpoint",

--- a/rita_client/src/dashboard/auth.rs
+++ b/rita_client/src/dashboard/auth.rs
@@ -16,7 +16,7 @@ pub fn set_pass(router_pass: Json<RouterPassword>) -> HttpResponse {
     debug!("Using {} as sha3 512 input", input_string);
     let mut hasher = Sha3_512::new();
     hasher.update(input_string.as_bytes());
-    let hashed_pass = bytes_to_hex_str(&hasher.finalize().to_vec());
+    let hashed_pass = bytes_to_hex_str(&hasher.finalize());
 
     let mut rita_client = settings::get_rita_client();
     rita_client.network.rita_dashboard_password = Some(hashed_pass);

--- a/rita_client/src/dashboard/interfaces.rs
+++ b/rita_client/src/dashboard/interfaces.rs
@@ -80,7 +80,7 @@ pub fn get_interfaces() -> Result<HashMap<String, InterfaceMode>, RitaClientErro
                         continue;
                     }
                     retval.insert(
-                        list_member.replace(" ", "").to_string(),
+                        list_member.replace(' ', "").to_string(),
                         ethernet2mode(&value, &setting_name)?,
                     );
                 }
@@ -211,7 +211,7 @@ pub fn ethernet_transform_mode(
     let mut return_codes = Vec::new();
     // in case of failure we revert to here
     let old_network_settings = { network.clone() };
-    let filtered_ifname = format!("network.rita_{}", ifname.replace(".", ""));
+    let filtered_ifname = format!("network.rita_{}", ifname.replace('.', ""));
 
     match a {
         // Wan is very simple, just delete it
@@ -563,7 +563,7 @@ pub fn list_remove(list: &str, entry: &str) -> String {
                 trace!("{} is not {} it's on the list!", filtered_item, entry);
                 let tmp_list = new_list.to_string();
                 if first {
-                    new_list = tmp_list + &filtered_item.to_string();
+                    new_list = tmp_list + filtered_item;
                     first = false;
                 } else {
                     new_list = tmp_list + &format!(" {}", filtered_item);

--- a/rita_client/src/heartbeat/mod.rs
+++ b/rita_client/src/heartbeat/mod.rs
@@ -177,24 +177,22 @@ fn send_udp_heartbeat() {
     match dns_request {
         Ok(dnsres) => {
             let dnsresult = VecDeque::from_iter(dnsres);
-            let selected_exit_route: Result<RouteLegacy, BabelMonitorError>;
-            if cfg!(feature = "operator_debug") {
-                selected_exit_route = Ok(dummy_route());
+            let selected_exit_route = if cfg!(feature = "operator_debug") {
+                Ok(dummy_route())
             } else {
-                selected_exit_route = get_selected_exit_route(&network_info.babel_routes);
-            }
+                get_selected_exit_route(&network_info.babel_routes)
+            };
 
             match selected_exit_route {
                 Ok(route) => {
-                    let neigh_option;
-                    if cfg!(feature = "operator_debug") {
-                        neigh_option = Some((dummy_neigh_babel(), dummy_neigh_tunnel()));
+                    let neigh_option = if cfg!(feature = "operator_debug") {
+                        Some((dummy_neigh_babel(), dummy_neigh_tunnel()))
                     } else {
                         let neigh_option1 =
                             get_neigh_given_route(&route, &network_info.babel_neighbors);
-                        neigh_option =
-                            get_rita_neigh_option(neigh_option1, &network_info.rita_neighbors);
-                    }
+
+                        get_rita_neigh_option(neigh_option1, &network_info.rita_neighbors)
+                    };
 
                     if let Some((neigh, rita_neigh)) = neigh_option {
                         // Now that we have all the info we can stop and try to update the

--- a/rita_common/src/blockchain_oracle/mod.rs
+++ b/rita_common/src/blockchain_oracle/mod.rs
@@ -273,9 +273,7 @@ fn update_gas_price(
     payment_settings: &mut PaymentSettings,
 ) {
     //local variables to be set
-    let oracle_gas_price: Uint256;
     let mut oracle_pay_thresh: Int256 = 0u128.into();
-    let oracle_close_thresh: Int256;
     // Minimum gas price. When gas is below this, we set gasprice to this value, which is then used to
     // calculate pay and close thresh
     let min_gas = payment_settings.min_gas.clone();
@@ -288,7 +286,7 @@ fn update_gas_price(
 
     // taking the latest gas value for pay_thres and close_thres calculation does better
     // in the worst case compared to averaging
-    oracle_gas_price = value;
+    let oracle_gas_price = value;
 
     let oracle_gas_price = if oracle_gas_price < min_gas {
         info!("gas price is low setting to! {}", min_gas);
@@ -307,7 +305,7 @@ fn update_gas_price(
     }
     trace!("Dynamically set pay threshold to {:?}", oracle_pay_thresh);
 
-    oracle_close_thresh = sign_flip * CLOSE_THRESH_MULT.into() * oracle_pay_thresh.clone();
+    let oracle_close_thresh = sign_flip * CLOSE_THRESH_MULT.into() * oracle_pay_thresh.clone();
     trace!(
         "Dynamically set close threshold to {:?}",
         oracle_close_thresh

--- a/rita_common/src/peer_listener/mod.rs
+++ b/rita_common/src/peer_listener/mod.rs
@@ -246,7 +246,7 @@ fn receive_im_here(
                 sock_addr
             );
 
-            let ipaddr = match PeerMessage::decode(&datagram.to_vec()) {
+            let ipaddr = match PeerMessage::decode(datagram.as_ref()) {
                 Ok(PeerMessage::ImHere(ipaddr)) => ipaddr,
                 Err(e) => {
                     warn!("ImHere decode failed: {:?}", e);

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -253,7 +253,7 @@ pub fn get_client_debt(client: Json<Identity>) -> HttpResponse {
         if debt.identity == client {
             let client_debt = debt.payment_details.debt;
             let incoming_payments = debt.payment_details.incoming_payments;
-            
+
             let we_owe_them = client_debt > zero;
             let they_owe_more_than_in_queue =
                 client_debt.to_uint256().unwrap() > unverified_payments_uint;

--- a/scripts/build_exit.sh
+++ b/scripts/build_exit.sh
@@ -1,12 +1,29 @@
 #!/bin/bash
+# Usage: ./linux_build_static [--debug] [--release]
+#
+# This script builds a static Linux binaries.
+#
+# Options:
+#   --debug (optional) Use debug profile
+#   --release (optional) Use release profile (default)
+#   --features (optional) List of features to build
+#
+# Note: You may need to disable or modify selinux, or add $USER to docker group
+# to be able to use `docker`.
 set -eux
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-echo $DIR
 
-pushd $DIR/../cross-builders/exit
-docker build -t cross-with-clang-ssl .
-cp Cross.toml ../..
-popd
-pushd $DIR/..
-cross build --release --target x86_64-unknown-linux-gnu  -p rita_bin --bin rita_exit
-rm Cross.toml
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
+RUST_TOOLCHAIN="stable"
+CARGO_ROOT="$HOME/.cargo"
+CARGO_GIT="$CARGO_ROOT/.git"
+CARGO_REGISTRY="$CARGO_ROOT/registry"
+
+docker pull ekidd/rust-musl-builder
+RUST_MUSL_BUILDER="docker run --rm -it -v "$(pwd)":/home/rust/src -v $CARGO_GIT:/home/rust/.cargo/git -v $CARGO_REGISTRY:/home/rust/.cargo/registry ekidd/rust-musl-builder"
+$RUST_MUSL_BUILDER sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry
+
+$RUST_MUSL_BUILDER cargo build --all ${PROFILE} ${FEATURES}


### PR DESCRIPTION
Recent events where xdai has placed stale paymetns on chain after a very
long time in the queue challenges a core assumption of payment_validator
mainly that payments will either execute or fail within 15 minutes.

This patch dramatically increases that timing to 72 hours and in the
process addresses some key issues that may make this long timeout
impractical.

Payment verification is now made parallel and the locking structure has
been re-arranged to avoid holding any lock while awaiting, this is
essential for the efficient execution of the exit debts endpoint which
now needs to aquire a read lock on this data quite often.