### PR TITLE
Update dependencies for Actix 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,18 +19,42 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "smallvec",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
+]
+
+[[package]]
+name = "actix"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
+dependencies = [
+ "actix-rt",
+ "actix_derive",
+ "bitflags",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.0",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util 0.7.0",
 ]
 
 [[package]]
 name = "actix-codec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36c014a3e811624313b51a227b775ecba55d36ef9462bbaac7d4f13e54c9271"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
  "bitflags",
  "bytes",
@@ -40,14 +64,14 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.0",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.0.0-beta.18"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b95871724d27ac9a23d6db3246b23e4e42cd44a23145e1c6b04b78fb5271da"
+checksum = "0f3fdd63b9cfeaf92eeeece719dabbddddb420a57d3fd171ce1490ecfb7086b1"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -57,7 +81,7 @@ dependencies = [
  "ahash",
  "base64 0.13.0",
  "bitflags",
- "brotli2",
+ "brotli",
  "bytes",
  "bytestring",
  "derive_more",
@@ -68,41 +92,31 @@ dependencies = [
  "http",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa",
  "language-tags",
  "local-channel",
  "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "sha-1 0.10.0",
  "smallvec",
  "zstd",
 ]
 
 [[package]]
-name = "actix-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "actix-router"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bdca166b1041184e2108ef05bd9909ec18cc6abc41152d31d30224cebfaac75"
+checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
 dependencies = [
  "bytestring",
  "firestorm",
  "http",
  "log",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -111,7 +125,6 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3f2183be1241ed4dd22611850b85d38de0b08a09f1f7bcccbd0809084b359"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -128,7 +141,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "log",
- "mio 0.8.0",
+ "mio",
  "num_cpus",
  "socket2",
  "tokio",
@@ -147,22 +160,21 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b161450ff646361005a300716e85856780ddc2fde569fd81335cc3c15b2e0933"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "derive_more",
  "futures-core",
  "http",
  "log",
  "openssl",
  "pin-project-lite",
  "tokio-openssl",
- "tokio-util",
+ "tokio-util 0.7.0",
 ]
 
 [[package]]
@@ -177,60 +189,47 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.0-beta.20"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8ba5081e9f8d0016cf34df516c699198158fd8c77990aa284115b055ead61b"
+checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
 dependencies = [
  "actix-codec",
  "actix-http",
- "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "actix-web-codegen",
  "ahash",
  "bytes",
+ "bytestring",
  "cfg-if",
  "derive_more",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa 1.0.1",
+ "itoa",
  "language-tags",
  "log",
  "mime",
  "once_cell",
  "pin-project-lite",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.5",
+ "time 0.3.7",
  "url",
 ]
 
 [[package]]
-name = "actix-web-codegen"
-version = "0.5.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a793e4a7bd059e06e1bc1bd9943b57a47f806de3599d2437441682292c333e"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "actix-web-httpauth"
-version = "0.6.0-beta.7"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ff332baee0f5ce55d94c690acb33a390d04a458d4bbd40a593cf847ac74ba4"
+checksum = "08c25a48b4684f90520183cd1a688e5f4f7e9905835fa75d02c0fe4f60fcdbe6"
 dependencies = [
  "actix-service",
  "actix-utils",
@@ -279,6 +278,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "althea_kernel_interface"
 version = "0.1.0"
 dependencies = [
@@ -288,7 +302,7 @@ dependencies = [
  "log",
  "oping",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
 ]
 
@@ -308,8 +322,8 @@ dependencies = [
  "lettre",
  "num256",
  "phonenumber",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "sodiumoxide",
@@ -327,8 +341,8 @@ dependencies = [
  "lazy_static",
  "log",
  "oping",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "sodiumoxide",
 ]
@@ -341,8 +355,8 @@ dependencies = [
  "clarity",
  "lazy_static",
  "log",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "sodiumoxide",
@@ -360,7 +374,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -390,14 +404,14 @@ dependencies = [
 name = "auto-bridge"
 version = "0.1.5"
 dependencies = [
- "actix",
+ "actix 0.13.0",
  "clarity",
- "futures 0.3.19",
+ "futures 0.3.21",
  "log",
  "num 0.4.0",
  "num256",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_derive",
  "tokio",
  "web30",
@@ -405,21 +419,24 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "awc"
-version = "3.0.0-beta.18"
+version = "3.0.0-beta.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e43f507fc706cf150b5a923655c96101692db9360148038678700fc4172e0a"
+checksum = "d91ad5074d7d2d8be6ef74d4ecb79c0f4d5f58bdc7ec896d5fbaa9f2fb9bfa5e"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -437,14 +454,14 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "itoa 1.0.1",
+ "itoa",
  "log",
  "mime",
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.4",
- "serde 1.0.133",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -458,7 +475,7 @@ dependencies = [
  "env_logger",
  "ipnetwork 0.18.0",
  "log",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
 ]
 
@@ -470,7 +487,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom",
  "instant",
- "rand 0.8.4",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -504,7 +521,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -538,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
 ]
@@ -555,23 +572,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
+name = "brotli"
+version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
+checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
 dependencies = [
- "cc",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
-name = "brotli2"
-version = "0.3.2"
+name = "brotli-decompressor"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
- "brotli-sys",
- "libc",
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -621,9 +639,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -658,7 +676,7 @@ dependencies = [
  "num-traits 0.2.14",
  "num256",
  "secp256k1",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-rlp",
  "serde_bytes",
  "serde_derive",
@@ -685,9 +703,9 @@ dependencies = [
  "ipgen",
  "lazy_static",
  "log",
- "rand 0.8.4",
+ "rand 0.8.5",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "settings",
@@ -700,15 +718,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e8d927ae6eec4ece3a1b6cd1a148c29c8000cc2e973b30c37f2c13f695b2a33"
 dependencies = [
- "actix",
+ "actix 0.12.0",
  "awc",
  "backoff",
  "chrono",
  "flate2",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "log",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
 ]
@@ -722,7 +740,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -742,15 +760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.3.5",
+ "time 0.3.7",
  "version_check 0.9.4",
 ]
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -773,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -792,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -802,11 +820,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -886,13 +905,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.2",
  "crypto-common",
- "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -903,7 +921,7 @@ checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
 dependencies = [
  "lazy_static",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "strsim",
 ]
 
@@ -915,9 +933,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "ed25519"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
 dependencies = [
  "signature",
 ]
@@ -1046,7 +1064,7 @@ dependencies = [
  "althea_types",
  "diesel",
  "dotenv",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
 ]
@@ -1068,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -1144,9 +1162,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1159,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1169,15 +1187,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1187,15 +1205,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1204,21 +1222,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1282,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1293,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1306,7 +1324,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1326,7 +1344,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "quick-error",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
 ]
 
@@ -1375,7 +1393,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -1391,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1409,9 +1427,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1422,7 +1440,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1461,7 +1479,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown",
 ]
 
@@ -1502,7 +1520,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1522,12 +1540,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1605,7 +1617,7 @@ dependencies = [
  "log",
  "native-tls",
  "nom 4.2.3",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
 ]
@@ -1639,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libsodium-sys"
@@ -1681,9 +1693,9 @@ checksum = "902eb695eb0591864543cbfbf6d742510642a605a61fc5e97fe6ceb5a30ac4fb"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1730,7 +1742,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1746,20 +1758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi 0.3.9",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1838,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -1879,7 +1878,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1890,10 +1889,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1902,7 +1901,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits 0.2.14",
 ]
 
@@ -1932,7 +1931,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits 0.2.14",
 ]
 
@@ -1942,7 +1941,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1953,7 +1952,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits 0.2.14",
@@ -1965,7 +1964,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-bigint 0.4.3",
  "num-integer",
  "num-traits 0.2.14",
@@ -1986,20 +1985,20 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "num256"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e9b9979a57886a71542e25e9ca7a0c84c7a2bd8c7c05a97e0b4564b3cb4b77"
+checksum = "aa9b5179e82f0867b23e0b9b822493821f9345561f271364f409c8e4a058367d"
 dependencies = [
  "lazy_static",
  "num 0.4.0",
  "num-derive",
  "num-traits 0.2.14",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
 ]
 
@@ -2010,6 +2009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -2072,7 +2080,7 @@ version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "openssl-src",
@@ -2108,7 +2116,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2123,6 +2141,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2195,7 +2226,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "regex-cache",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "thiserror",
 ]
@@ -2259,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -2273,7 +2304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "scheduled-thread-pool",
 ]
 
@@ -2296,11 +2327,11 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc 0.1.0",
+ "rand_hc",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
@@ -2311,14 +2342,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2327,7 +2357,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.3.1",
 ]
 
@@ -2375,15 +2405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,7 +2444,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.4.2",
 ]
 
@@ -2447,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2516,7 +2537,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -2532,7 +2553,7 @@ dependencies = [
 name = "rita_bin"
 version = "0.19.2"
 dependencies = [
- "actix",
+ "actix 0.13.0",
  "actix-web",
  "althea_kernel_interface",
  "althea_types",
@@ -2556,7 +2577,7 @@ dependencies = [
  "rita_client",
  "rita_common",
  "rita_exit",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_json",
  "settings",
 ]
@@ -2565,7 +2586,7 @@ dependencies = [
 name = "rita_client"
 version = "0.19.2"
 dependencies = [
- "actix",
+ "actix 0.13.0",
  "actix-web",
  "actix-web-httpauth",
  "althea_kernel_interface",
@@ -2587,7 +2608,7 @@ dependencies = [
  "num256",
  "phonenumber",
  "rita_common",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "settings",
@@ -2600,7 +2621,7 @@ dependencies = [
 name = "rita_common"
 version = "0.19.2"
 dependencies = [
- "actix",
+ "actix 0.13.0",
  "actix-service",
  "actix-web",
  "actix-web-httpauth",
@@ -2617,17 +2638,16 @@ dependencies = [
  "compressed_log",
  "docopt",
  "flate2",
- "futures 0.1.31",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hex-literal",
  "ipnetwork 0.18.0",
  "lazy_static",
  "log",
  "num-traits 0.2.14",
  "num256",
- "rand 0.8.4",
+ "rand 0.8.5",
  "regex",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -2639,7 +2659,7 @@ dependencies = [
 name = "rita_exit"
 version = "0.19.2"
 dependencies = [
- "actix",
+ "actix 0.13.0",
  "actix-web",
  "althea_kernel_interface",
  "althea_types",
@@ -2659,10 +2679,10 @@ dependencies = [
  "num256",
  "phonenumber",
  "r2d2",
- "rand 0.8.4",
+ "rand 0.8.5",
  "reqwest",
  "rita_common",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "settings",
@@ -2721,7 +2741,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -2732,9 +2752,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -2750,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2763,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2773,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -2785,9 +2805,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -2813,7 +2833,7 @@ dependencies = [
  "byteorder",
  "error",
  "num 0.2.1",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2822,7 +2842,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2832,14 +2852,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2848,13 +2868,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2864,9 +2884,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2885,7 +2905,7 @@ dependencies = [
  "num256",
  "owning_ref",
  "phonenumber",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "toml",
@@ -2911,16 +2931,16 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.1",
+ "digest 0.10.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
+checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "digest 0.10.1",
+ "digest 0.10.3",
  "keccak",
 ]
 
@@ -2953,9 +2973,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2970,7 +2990,7 @@ dependencies = [
  "ed25519",
  "libc",
  "libsodium-sys",
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3063,12 +3083,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
- "itoa 0.4.8",
+ "itoa",
  "libc",
+ "num_threads",
  "time-macros",
 ]
 
@@ -3095,19 +3116,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi 0.3.9",
 ]
@@ -3160,12 +3182,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.133",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3176,9 +3212,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -3187,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
 ]
@@ -3389,18 +3425,18 @@ dependencies = [
 
 [[package]]
 name = "web30"
-version = "0.18.3"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801b7d45749b1cb71167b15c955eeaf4261ed5a95659234912a627f44fbf65d7"
+checksum = "f1b1a9edb58d8c038a6667457832586ed16f03d265211485700ed1c559583947"
 dependencies = [
  "awc",
  "clarity",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "log",
  "num 0.4.0",
  "num256",
- "serde 1.0.133",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
  "tokio",
@@ -3444,6 +3480,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,18 +3551,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.9.2+zstd.1.5.1"
+version = "0.10.0+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2390ea1bf6c038c39674f22d95f0564725fc06034a47129179810b2fc58caa54"
+checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.3+zstd.1.5.1"
+version = "4.1.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99d81b99fb3c2c2c794e3fe56c305c63d5173a16a46b5850b07c935ffc7db79"
+checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -3491,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.2+zstd.1.5.1"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daf2f248d9ea44454bfcb2516534e8b8ad2fc91bf818a1885495fc42bc8ac9f"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",

--- a/auto_bridge/Cargo.toml
+++ b/auto_bridge/Cargo.toml
@@ -17,5 +17,5 @@ tokio = "1.0"
 futures = {version="0.3", features = ["thread-pool"]}
 
 [dev-dependencies]
-actix = "0.12"
+actix = "0.13"
 futures = "0.3"

--- a/rita_bin/Cargo.toml
+++ b/rita_bin/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/client.rs"
 althea_kernel_interface = { path = "../althea_kernel_interface" }
 althea_types = { path = "../althea_types"}
 clu = { path = "../clu" }
-actix-async = {package="actix", version = "0.12"}
-actix-web-async = {package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"] }
+actix-async = {package="actix", version = "0.13"}
+actix-web-async = {package="actix-web", version = "4.0.1", default_features = false, features= ["openssl"] }
 docopt = "1.1"
 compressed_log = "0.5"
 settings = { path = "../settings" }

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -29,11 +29,11 @@ arrayvec = {version= "0.7", features = ["serde"]}
 sodiumoxide = "0.2"
 clu = { path = "../clu" }
 web30 = "0.18"
-awc = "3.0.0-beta.18"
+awc = "3.0.0-beta.21"
 ipnetwork = "0.18"
-actix-async = {package="actix", version = "0.12"}
-actix-web-async = { package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"]}
-actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0-beta.7"}
+actix-async = {package="actix", version = "0.13"}
+actix-web-async = { package="actix-web", version = "4.0.1", default_features = false, features= ["openssl"]}
+actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0"}
 clarity = "0.5"
 
 [lib]

--- a/rita_client/src/dashboard/auth.rs
+++ b/rita_client/src/dashboard/auth.rs
@@ -8,7 +8,7 @@ pub struct RouterPassword {
     pub password: String,
 }
 
-pub fn set_pass(router_pass: Json<RouterPassword>) -> HttpResponse {
+pub async fn set_pass(router_pass: Json<RouterPassword>) -> HttpResponse {
     debug!("/router/password hit with {:?}", router_pass);
     let router_pass = router_pass.into_inner();
     let input_string = router_pass.password.clone() + "RitaSalt";

--- a/rita_client/src/dashboard/backup_created.rs
+++ b/rita_client/src/dashboard/backup_created.rs
@@ -2,7 +2,7 @@ use actix_web_async::{http::StatusCode, web::Path, HttpRequest, HttpResponse};
 use rita_common::RitaCommonError;
 use std::collections::HashMap;
 
-pub fn get_backup_created(_req: HttpRequest) -> HttpResponse {
+pub async fn get_backup_created(_req: HttpRequest) -> HttpResponse {
     debug!("/backup_created GET hit");
     let mut ret = HashMap::new();
     ret.insert(
@@ -16,7 +16,7 @@ pub fn get_backup_created(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(ret)
 }
 
-pub fn set_backup_created(path: Path<bool>) -> HttpResponse {
+pub async fn set_backup_created(path: Path<bool>) -> HttpResponse {
     debug!("Setting backup created");
     let value = path.into_inner();
 

--- a/rita_client/src/dashboard/bandwidth_limit.rs
+++ b/rita_client/src/dashboard/bandwidth_limit.rs
@@ -6,12 +6,12 @@ use actix_web_async::HttpResponse;
 use actix_web_async::{web::Path, HttpRequest};
 use rita_common::{RitaCommonError, KI};
 
-pub fn get_bandwidth_limit(_req: HttpRequest) -> HttpResponse {
+pub async fn get_bandwidth_limit(_req: HttpRequest) -> HttpResponse {
     let val = settings::get_rita_client().network.user_bandwidth_limit;
     HttpResponse::Ok().json(val)
 }
 
-pub fn set_bandwidth_limit(path: Path<String>) -> HttpResponse {
+pub async fn set_bandwidth_limit(path: Path<String>) -> HttpResponse {
     let value = path.into_inner();
     debug!("Set bandwidth limit!");
     let mut rita_client = settings::get_rita_client();

--- a/rita_client/src/dashboard/contact_info.rs
+++ b/rita_client/src/dashboard/contact_info.rs
@@ -14,7 +14,7 @@ fn clean_quotes(val: &str) -> String {
     val.trim().trim_matches('"').trim_matches('\\').to_string()
 }
 
-pub fn set_phone_number(req: String) -> HttpResponse {
+pub async fn set_phone_number(req: String) -> HttpResponse {
     let clean_string = clean_quotes(&req);
     trace!("Got number {:?}", clean_string);
     let number: PhoneNumber = match clean_string.parse() {
@@ -50,7 +50,7 @@ pub fn set_phone_number(req: String) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn get_phone_number(_req: HttpRequest) -> HttpResponse {
+pub async fn get_phone_number(_req: HttpRequest) -> HttpResponse {
     let rita_client = settings::get_rita_client();
     let exit_client = rita_client.exit_client;
     match &option_convert(exit_client.contact_info) {
@@ -63,7 +63,7 @@ pub fn get_phone_number(_req: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn set_email(req: String) -> HttpResponse {
+pub async fn set_email(req: String) -> HttpResponse {
     let clean_string = clean_quotes(&req);
     trace!("Got email {:?}", clean_string);
     let email: EmailAddress = match clean_string.parse() {
@@ -98,7 +98,7 @@ pub fn set_email(req: String) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn get_email(_req: HttpRequest) -> HttpResponse {
+pub async fn get_email(_req: HttpRequest) -> HttpResponse {
     let rita_client = settings::get_rita_client();
     let exit_client = rita_client.exit_client;
     match &option_convert(exit_client.contact_info) {

--- a/rita_client/src/dashboard/eth_private_key.rs
+++ b/rita_client/src/dashboard/eth_private_key.rs
@@ -6,7 +6,7 @@ pub struct EthPrivateKey {
     pub eth_private_key: String,
 }
 
-pub fn get_eth_private_key(_req: HttpRequest) -> HttpResponse {
+pub async fn get_eth_private_key(_req: HttpRequest) -> HttpResponse {
     debug!("/eth_private_key GET hit");
 
     let mut ret = HashMap::new();

--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -113,7 +113,7 @@ pub fn dashboard_get_exit_info() -> Result<Vec<ExitInfo>, RitaClientError> {
     }
 }
 
-pub fn add_exits(new_exits: Json<HashMap<String, ExitServer>>) -> HttpResponse {
+pub async fn add_exits(new_exits: Json<HashMap<String, ExitServer>>) -> HttpResponse {
     debug!("/exits POST hit with {:?}", new_exits);
     let mut rita_client = settings::get_rita_client();
     let mut exits = rita_client.exit_client.exits;
@@ -127,7 +127,7 @@ pub fn add_exits(new_exits: Json<HashMap<String, ExitServer>>) -> HttpResponse {
     HttpResponse::Ok().json(copy)
 }
 
-pub fn get_exit_info(_req: HttpRequest) -> HttpResponse {
+pub async fn get_exit_info(_req: HttpRequest) -> HttpResponse {
     debug!("Exit endpoint hit!");
     match dashboard_get_exit_info() {
         Ok(a) => HttpResponse::Ok().json(a),
@@ -135,7 +135,7 @@ pub fn get_exit_info(_req: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn reset_exit(path: Path<String>) -> HttpResponse {
+pub async fn reset_exit(path: Path<String>) -> HttpResponse {
     let exit_name = path.into_inner();
     debug!("/exits/{}/reset hit", exit_name);
     let mut rita_client = settings::get_rita_client();
@@ -167,7 +167,7 @@ pub fn reset_exit(path: Path<String>) -> HttpResponse {
     }
 }
 
-pub fn select_exit(path: Path<String>) -> HttpResponse {
+pub async fn select_exit(path: Path<String>) -> HttpResponse {
     let exit_name = path.into_inner();
     debug!("/exits/{}/select hit", exit_name);
 

--- a/rita_client/src/dashboard/installation_details.rs
+++ b/rita_client/src/dashboard/installation_details.rs
@@ -25,7 +25,7 @@ pub struct InstallationDetailsPost {
     pub equipment_details: String,
 }
 
-pub fn set_installation_details(req: Json<InstallationDetailsPost>) -> HttpResponse {
+pub async fn set_installation_details(req: Json<InstallationDetailsPost>) -> HttpResponse {
     let input = req.into_inner();
     trace!("Setting install details with {:?}", input);
 
@@ -126,17 +126,17 @@ pub fn set_installation_details(req: Json<InstallationDetailsPost>) -> HttpRespo
     HttpResponse::Ok().finish()
 }
 
-pub fn get_installation_details(_req: HttpRequest) -> HttpResponse {
+pub async fn get_installation_details(_req: HttpRequest) -> HttpResponse {
     let rita_client = settings::get_rita_client();
     let operator_settings = rita_client.operator;
     HttpResponse::Ok().json(operator_settings.installation_details)
 }
 
-pub fn display_operator_setup(_req: HttpRequest) -> HttpResponse {
+pub async fn display_operator_setup(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(settings::get_rita_client().operator.display_operator_setup)
 }
 
-pub fn set_display_operator_setup(val: Path<bool>) -> HttpResponse {
+pub async fn set_display_operator_setup(val: Path<bool>) -> HttpResponse {
     // scoped so that this value gets dropped before we get to save, preventing
     // deadlock
     {
@@ -155,13 +155,13 @@ pub fn set_display_operator_setup(val: Path<bool>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn get_billing_details(_req: HttpRequest) -> HttpResponse {
+pub async fn get_billing_details(_req: HttpRequest) -> HttpResponse {
     let rita_client = settings::get_rita_client();
     let operator_settings = rita_client.operator;
     HttpResponse::Ok().json(operator_settings.billing_details)
 }
 
-pub fn set_billing_details(req: Json<BillingDetails>) -> HttpResponse {
+pub async fn set_billing_details(req: Json<BillingDetails>) -> HttpResponse {
     let mut rita_client = settings::get_rita_client();
     let mut operator = rita_client.operator;
     operator.billing_details = Some(req.into_inner());

--- a/rita_client/src/dashboard/interfaces.rs
+++ b/rita_client/src/dashboard/interfaces.rs
@@ -437,7 +437,7 @@ fn wlan_toggle_get(uci_spec: &str) -> Result<bool, RitaClientError> {
     Ok(current_state)
 }
 
-pub fn wlan_mesh_get(_: HttpRequest) -> HttpResponse {
+pub async fn wlan_mesh_get(_: HttpRequest) -> HttpResponse {
     let res = wlan_toggle_get("wireless.mesh.disabled");
     match res {
         Ok(b) => HttpResponse::Ok().json(b),
@@ -448,7 +448,7 @@ pub fn wlan_mesh_get(_: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn wlan_lightclient_get(_: HttpRequest) -> HttpResponse {
+pub async fn wlan_lightclient_get(_: HttpRequest) -> HttpResponse {
     let res = wlan_toggle_get("wireless.lightclient.disabled");
     match res {
         Ok(b) => HttpResponse::Ok().json(b),
@@ -518,7 +518,7 @@ fn wlan_toggle_set(uci_spec: &str, enabled: bool) -> Result<(), RitaClientError>
     Ok(())
 }
 
-pub fn wlan_mesh_set(enabled: Path<bool>) -> HttpResponse {
+pub async fn wlan_mesh_set(enabled: Path<bool>) -> HttpResponse {
     let enabled = enabled.into_inner();
     let res = wlan_toggle_set("wireless.mesh.disabled", enabled);
     match res {
@@ -530,7 +530,7 @@ pub fn wlan_mesh_set(enabled: Path<bool>) -> HttpResponse {
     }
 }
 
-pub fn wlan_lightclient_set(enabled: Path<bool>) -> HttpResponse {
+pub async fn wlan_lightclient_set(enabled: Path<bool>) -> HttpResponse {
     let enabled = enabled.into_inner();
     let res = wlan_toggle_set("wireless.lightclient.disabled", enabled);
     match res {
@@ -629,7 +629,7 @@ mod tests {
     }
 }
 
-pub fn get_interfaces_endpoint(_req: HttpRequest) -> HttpResponse {
+pub async fn get_interfaces_endpoint(_req: HttpRequest) -> HttpResponse {
     debug!("get /interfaces hit");
     match get_interfaces() {
         Ok(val) => HttpResponse::Ok().json(val),
@@ -640,7 +640,7 @@ pub fn get_interfaces_endpoint(_req: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn set_interfaces_endpoint(interface: Json<InterfaceToSet>) -> HttpResponse {
+pub async fn set_interfaces_endpoint(interface: Json<InterfaceToSet>) -> HttpResponse {
     let interface = interface.into_inner();
     debug!("set /interfaces hit");
 

--- a/rita_client/src/dashboard/localization.rs
+++ b/rita_client/src/dashboard/localization.rs
@@ -29,7 +29,7 @@ impl From<LocalizationSettings> for LocalizationReturn {
     }
 }
 
-pub fn get_localization(_req: HttpRequest) -> HttpResponse {
+pub async fn get_localization(_req: HttpRequest) -> HttpResponse {
     debug!("/localization GET hit");
     let localization = settings::get_rita_client().localization;
     HttpResponse::Ok().json(localization)

--- a/rita_client/src/dashboard/logging.rs
+++ b/rita_client/src/dashboard/logging.rs
@@ -3,11 +3,11 @@ use actix_web_async::{web::Path, HttpRequest, HttpResponse};
 use log::LevelFilter;
 use rita_common::KI;
 
-pub fn get_remote_logging(_req: HttpRequest) -> HttpResponse {
+pub async fn get_remote_logging(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(settings::get_rita_client().log.enabled)
 }
 
-pub fn remote_logging(path: Path<bool>) -> HttpResponse {
+pub async fn remote_logging(path: Path<bool>) -> HttpResponse {
     let enabled = path.into_inner();
     debug!("/remote_logging/enable/{} hit", enabled);
 
@@ -33,13 +33,13 @@ pub fn remote_logging(path: Path<bool>) -> HttpResponse {
     HttpResponse::Ok().json(())
 }
 
-pub fn get_remote_logging_level(_req: HttpRequest) -> HttpResponse {
+pub async fn get_remote_logging_level(_req: HttpRequest) -> HttpResponse {
     let rita_client = settings::get_rita_client();
     let level = &rita_client.log.level;
     HttpResponse::Ok().json(level)
 }
 
-pub fn remote_logging_level(path: Path<String>) -> HttpResponse {
+pub async fn remote_logging_level(path: Path<String>) -> HttpResponse {
     let level = path.into_inner();
     debug!("/remote_logging/level/{}", level);
 

--- a/rita_client/src/dashboard/mesh_ip.rs
+++ b/rita_client/src/dashboard/mesh_ip.rs
@@ -1,7 +1,7 @@
 use actix_web_async::{HttpRequest, HttpResponse};
 use std::collections::HashMap;
 
-pub fn get_mesh_ip(_req: HttpRequest) -> HttpResponse {
+pub async fn get_mesh_ip(_req: HttpRequest) -> HttpResponse {
     debug!("/mesh_ip GET hit");
 
     let mut ret = HashMap::new();

--- a/rita_client/src/dashboard/neighbors.rs
+++ b/rita_client/src/dashboard/neighbors.rs
@@ -33,7 +33,7 @@ pub struct NodeInfo {
     pub stats: IfaceStats,
 }
 
-pub fn get_routes(_req: HttpRequest) -> HttpResponse {
+pub async fn get_routes(_req: HttpRequest) -> HttpResponse {
     let babel_port = settings::get_rita_client().network.babel_port;
     match open_babel_stream(babel_port, Duration::from_secs(5)) {
         Ok(mut stream) => match parse_routes(&mut stream) {
@@ -51,7 +51,7 @@ pub fn get_routes(_req: HttpRequest) -> HttpResponse {
 /// since the /debts endpoint was introduced, and should be removed when it can be
 /// coordinated with the frontend.
 /// The routes info might also belong in /exits or a dedicated /routes endpoint
-pub fn get_neighbor_info(_req: HttpRequest) -> HttpResponse {
+pub async fn get_neighbor_info(_req: HttpRequest) -> HttpResponse {
     let debts = dump();
     let neighbors = tm_get_neighbors();
     let combined_list = merge_debts_and_neighbors(neighbors, debts);

--- a/rita_client/src/dashboard/notifications.rs
+++ b/rita_client/src/dashboard/notifications.rs
@@ -1,7 +1,7 @@
 use ::actix_web_async::web::Path;
 use ::actix_web_async::{HttpRequest, HttpResponse};
 
-pub fn get_low_balance_notification(_req: HttpRequest) -> HttpResponse {
+pub async fn get_low_balance_notification(_req: HttpRequest) -> HttpResponse {
     let setting = settings::get_rita_client()
         .exit_client
         .low_balance_notification;
@@ -9,7 +9,7 @@ pub fn get_low_balance_notification(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(setting.to_string())
 }
 
-pub fn set_low_balance_notification(path: Path<bool>) -> HttpResponse {
+pub async fn set_low_balance_notification(path: Path<bool>) -> HttpResponse {
     let value = path.into_inner();
     debug!("Set low balance notification hit!");
 

--- a/rita_client/src/dashboard/operator.rs
+++ b/rita_client/src/dashboard/operator.rs
@@ -6,7 +6,7 @@ use num256::Uint256;
 use std::collections::HashMap;
 
 /// TODO remove after beta 12, provided for backwards compat
-pub fn get_dao_list(_req: HttpRequest) -> HttpResponse {
+pub async fn get_dao_list(_req: HttpRequest) -> HttpResponse {
     trace!("get dao list: Hit");
     let rita_client = settings::get_rita_client();
     match rita_client.operator.operator_address {
@@ -19,7 +19,7 @@ pub fn get_dao_list(_req: HttpRequest) -> HttpResponse {
 }
 
 /// TODO remove after beta 12, provided for backwards compat
-pub fn add_to_dao_list(path: Path<Address>) -> HttpResponse {
+pub async fn add_to_dao_list(path: Path<Address>) -> HttpResponse {
     trace!("Add to dao list: Hit");
     let provided_address = path.into_inner();
     let mut rita_client = settings::get_rita_client();
@@ -33,7 +33,7 @@ pub fn add_to_dao_list(path: Path<Address>) -> HttpResponse {
 }
 
 /// TODO remove after beta 12, provided for backwards compat
-pub fn remove_from_dao_list(_path: Path<Address>) -> HttpResponse {
+pub async fn remove_from_dao_list(_path: Path<Address>) -> HttpResponse {
     let mut rita_client = settings::get_rita_client();
     let mut operator = rita_client.operator;
 
@@ -46,7 +46,7 @@ pub fn remove_from_dao_list(_path: Path<Address>) -> HttpResponse {
 }
 
 /// TODO remove after beta 12, provided for backwards compat
-pub fn get_dao_fee(_req: HttpRequest) -> HttpResponse {
+pub async fn get_dao_fee(_req: HttpRequest) -> HttpResponse {
     debug!("/dao_fee GET hit");
     let mut ret = HashMap::new();
     let rita_client = settings::get_rita_client();
@@ -56,7 +56,7 @@ pub fn get_dao_fee(_req: HttpRequest) -> HttpResponse {
 }
 
 /// TODO remove after beta 12, provided for backwards compat
-pub fn set_dao_fee(path: Path<Uint256>) -> HttpResponse {
+pub async fn set_dao_fee(path: Path<Uint256>) -> HttpResponse {
     let new_fee = path.into_inner();
     debug!("/dao_fee/{} POST hit", new_fee);
     let mut rita_client = settings::get_rita_client();
@@ -69,7 +69,7 @@ pub fn set_dao_fee(path: Path<Uint256>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn get_operator(_req: HttpRequest) -> HttpResponse {
+pub async fn get_operator(_req: HttpRequest) -> HttpResponse {
     trace!("get operator address: Hit");
     let rita_client = settings::get_rita_client();
     match rita_client.operator.operator_address {
@@ -81,7 +81,7 @@ pub fn get_operator(_req: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn change_operator(path: Path<Address>) -> HttpResponse {
+pub async fn change_operator(path: Path<Address>) -> HttpResponse {
     trace!("add operator address: Hit");
     let provided_address = path.into_inner();
     let mut rita_client = settings::get_rita_client();
@@ -95,7 +95,7 @@ pub fn change_operator(path: Path<Address>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn remove_operator(_path: Path<Address>) -> HttpResponse {
+pub async fn remove_operator(_path: Path<Address>) -> HttpResponse {
     let mut rita_client = settings::get_rita_client();
     let mut operator = rita_client.operator;
     operator.operator_address = None;
@@ -105,12 +105,12 @@ pub fn remove_operator(_path: Path<Address>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-pub fn get_operator_fee(_req: HttpRequest) -> HttpResponse {
+pub async fn get_operator_fee(_req: HttpRequest) -> HttpResponse {
     debug!("get operator GET hit");
     HttpResponse::Ok().json(settings::get_rita_client().operator.operator_fee)
 }
 
-pub fn get_operator_debt(_req: HttpRequest) -> HttpResponse {
+pub async fn get_operator_debt(_req: HttpRequest) -> HttpResponse {
     debug!("get operator debt hit");
     HttpResponse::Ok().json(get_operator_fee_debt())
 }

--- a/rita_client/src/dashboard/prices.rs
+++ b/rita_client/src/dashboard/prices.rs
@@ -5,12 +5,12 @@ use num256::Uint256;
 
 use crate::traffic_watcher::get_exit_dest_price;
 
-pub fn auto_pricing_status(_req: HttpRequest) -> HttpResponse {
+pub async fn auto_pricing_status(_req: HttpRequest) -> HttpResponse {
     debug!("Get Auto pricing enabled hit!");
     HttpResponse::Ok().json(settings::get_rita_client().operator.use_operator_price)
 }
 
-pub fn set_auto_pricing(path: Path<bool>) -> HttpResponse {
+pub async fn set_auto_pricing(path: Path<bool>) -> HttpResponse {
     let value = path.into_inner();
     debug!("Set Auto pricing enabled hit!");
     let mut rita_client = settings::get_rita_client();
@@ -37,7 +37,7 @@ pub struct Prices {
     simulated_tx_fee: u8,
 }
 
-pub fn get_prices(_req: HttpRequest) -> HttpResponse {
+pub async fn get_prices(_req: HttpRequest) -> HttpResponse {
     debug!("/prices GET hit");
 
     let payment = settings::get_rita_client().payment;

--- a/rita_client/src/dashboard/remote_access.rs
+++ b/rita_client/src/dashboard/remote_access.rs
@@ -12,7 +12,7 @@ use crate::RitaClientError;
 static DROPBEAR_CONFIG: &str = "/etc/config/dropbear";
 static FIREWALL_CONFIG: &str = "/etc/config/firewall";
 
-pub fn get_remote_access_status(_req: HttpRequest) -> HttpResponse {
+pub async fn get_remote_access_status(_req: HttpRequest) -> HttpResponse {
     if !KI.is_openwrt() {
         return HttpResponse::new(StatusCode::BAD_REQUEST);
     }
@@ -60,7 +60,7 @@ fn check_dropbear_config() -> Result<bool, RitaClientError> {
     Ok(true)
 }
 
-pub fn set_remote_access_status(path: Path<bool>) -> HttpResponse {
+pub async fn set_remote_access_status(path: Path<bool>) -> HttpResponse {
     let remote_access = path.into_inner();
     if let Err(e) = set_remote_access_internal(remote_access) {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));

--- a/rita_client/src/dashboard/router.rs
+++ b/rita_client/src/dashboard/router.rs
@@ -9,7 +9,7 @@ lazy_static! {
         Arc::new(RwLock::new(None));
 }
 
-pub fn reboot_router(_req: HttpRequest) -> HttpResponse {
+pub async fn reboot_router(_req: HttpRequest) -> HttpResponse {
     if KI.is_openwrt() {
         if let Err(e) = KI.run_command("reboot", &[]) {
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
@@ -24,7 +24,7 @@ pub fn reboot_router(_req: HttpRequest) -> HttpResponse {
 /// This function is triggered by the user from the router dashboard. Retrive the firmware image from
 /// the lazy static variable and use this to perform a sysupgrade. If device is not openwrt or no image
 /// link is available, do nothing
-pub fn update_router(_req: HttpRequest) -> HttpResponse {
+pub async fn update_router(_req: HttpRequest) -> HttpResponse {
     if KI.is_openwrt() {
         let reader = &*UPDATE_INSTRUCTION.read().unwrap();
         if reader.is_none() {

--- a/rita_client/src/dashboard/system_chain.rs
+++ b/rita_client/src/dashboard/system_chain.rs
@@ -8,7 +8,7 @@ use settings::payment::ETH_FEE_MULTIPLIER;
 use settings::payment::XDAI_FEE_MULTIPLIER;
 
 /// Changes the full node configuration value between test/prod and other networks
-pub fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse {
+pub async fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse {
     info!("Blockchain change endpoint hit!");
     let id: Result<SystemChain, ()> = path.into_inner().parse();
     if id.is_err() {
@@ -31,7 +31,7 @@ pub fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse {
     HttpResponse::Ok().json(())
 }
 
-pub fn get_system_blockchain(_req: HttpRequest) -> HttpResponse {
+pub async fn get_system_blockchain(_req: HttpRequest) -> HttpResponse {
     debug!("/blockchain/ GET hit");
 
     HttpResponse::Ok().json(settings::get_rita_client().payment.system_chain)

--- a/rita_client/src/dashboard/usage.rs
+++ b/rita_client/src/dashboard/usage.rs
@@ -2,13 +2,13 @@ use actix_web_async::{HttpRequest, HttpResponse};
 use rita_common::usage_tracker::get_usage_data;
 use rita_common::usage_tracker::UsageType;
 
-pub fn get_client_usage(_req: HttpRequest) -> HttpResponse {
+pub async fn get_client_usage(_req: HttpRequest) -> HttpResponse {
     trace!("/usage/client hit");
 
     HttpResponse::Ok().json(get_usage_data(UsageType::Client))
 }
 
-pub fn get_relay_usage(_req: HttpRequest) -> HttpResponse {
+pub async fn get_relay_usage(_req: HttpRequest) -> HttpResponse {
     trace!("/usage/relay hit");
 
     HttpResponse::Ok().json(get_usage_data(UsageType::Relay))

--- a/rita_client/src/dashboard/wifi.rs
+++ b/rita_client/src/dashboard/wifi.rs
@@ -274,7 +274,7 @@ pub enum WifiToken {
 /// an endpoint that takes a series of wifi tokens in json format and applies them all at once
 /// the reason for this is that changing any setting while on wifi will disconnect the caller
 /// so in order to have all the changes 'take' we need to have a single endpoint for all changes
-pub fn set_wifi_multi(wifi_changes: Json<Vec<WifiToken>>) -> HttpResponse {
+pub async fn set_wifi_multi(wifi_changes: Json<Vec<WifiToken>>) -> HttpResponse {
     trace!("Got multi wifi change!");
     let mut needs_reboot = false;
 
@@ -443,7 +443,7 @@ fn validate_channel(
 }
 
 // returns what channels are allowed for the provided radio value
-pub fn get_allowed_wifi_channels(radio: Path<String>) -> HttpResponse {
+pub async fn get_allowed_wifi_channels(radio: Path<String>) -> HttpResponse {
     debug!("/wifi_settings/get_channels hit with {:?}", radio);
     let radio = radio.into_inner();
 
@@ -532,7 +532,7 @@ fn validate_config_value(s: &str) -> Result<(), ValidationError> {
     }
 }
 
-pub fn get_wifi_config(_req: HttpRequest) -> HttpResponse {
+pub async fn get_wifi_config(_req: HttpRequest) -> HttpResponse {
     debug!("Get wificonfig hit!");
     let config = match get_wifi_config_internal() {
         Ok(con) => con,

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = { version = "1.4", features = ["i128"] }
 arrayvec = {version= "0.7", features = ["serde"]}
 babel_monitor = { path = "../babel_monitor" }
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
-actix-async = {package="actix", version = "0.12"}
+actix-async = {package="actix", version = "0.13"}
 auto-bridge = {path = "../auto_bridge"}
 serde_json = "1.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
@@ -26,14 +26,13 @@ clarity = "0.5"
 futures = { version = "0.3", features = ["compat"] }
 num256 = "0.3"
 num-traits="0.2"
-futures01 = { package = "futures", version = "0.1"}
 bincode = "1.3"
 serde_cbor = "0.11"
 lazy_static = "1.4"
 althea_kernel_interface = { path = "../althea_kernel_interface" }
-actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0-beta.7"}
-actix-web-async = { package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"]}
-awc = {version = "3.0.0-beta.8", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}
+actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.6.0"}
+actix-web-async = { package="actix-web", version = "4.0.1", default_features = false, features= ["openssl"]}
+awc = {version = "3.0.0-beta.21", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}
 actix-service = "2.0.2"
 web30 = "0.18"
 althea_types = { path = "../althea_types" }

--- a/rita_common/src/dashboard/babel.rs
+++ b/rita_common/src/dashboard/babel.rs
@@ -7,7 +7,7 @@ use babel_monitor::set_metric_factor as babel_set_metric_factor;
 use std::collections::HashMap;
 use std::time::Duration;
 
-pub fn get_local_fee(_req: HttpRequest) -> HttpResponse {
+pub async fn get_local_fee(_req: HttpRequest) -> HttpResponse {
     debug!("/local_fee GET hit");
     let mut ret = HashMap::new();
     ret.insert("local_fee", settings::get_rita_common().payment.local_fee);
@@ -15,7 +15,7 @@ pub fn get_local_fee(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(ret)
 }
 
-pub fn get_metric_factor(_req: HttpRequest) -> HttpResponse {
+pub async fn get_metric_factor(_req: HttpRequest) -> HttpResponse {
     debug!("/local_fee GET hit");
     let mut ret = HashMap::new();
     ret.insert(
@@ -26,7 +26,7 @@ pub fn get_metric_factor(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(ret)
 }
 
-pub fn set_local_fee(path: Path<u32>) -> HttpResponse {
+pub async fn set_local_fee(path: Path<u32>) -> HttpResponse {
     let new_fee = path.into_inner();
     debug!("/local_fee/{} POST hit", new_fee);
     let babel_port = settings::get_rita_common().network.babel_port;
@@ -66,7 +66,7 @@ pub fn set_local_fee(path: Path<u32>) -> HttpResponse {
 
 /// Sets the metric factor for this node, lower values mean a higher price preference while higher
 /// values mean a higher weight on route quality.
-pub fn set_metric_factor(path: Path<u32>) -> HttpResponse {
+pub async fn set_metric_factor(path: Path<u32>) -> HttpResponse {
     let new_factor = path.into_inner();
     debug!("/metric_factor/{} POST hit", new_factor);
     let babel_port = settings::get_rita_common().network.babel_port;

--- a/rita_common/src/dashboard/debts.rs
+++ b/rita_common/src/dashboard/debts.rs
@@ -4,12 +4,12 @@ use crate::debt_keeper::Traffic;
 use actix_web_async::{web::Json, HttpRequest, HttpResponse};
 use althea_types::Identity;
 
-pub fn get_debts(_req: HttpRequest) -> HttpResponse {
+pub async fn get_debts(_req: HttpRequest) -> HttpResponse {
     trace!("get_debts: Hit");
     HttpResponse::Ok().json(get_debts_list())
 }
 
-pub fn reset_debt(user_to_forgive: Json<Identity>) -> HttpResponse {
+pub async fn reset_debt(user_to_forgive: Json<Identity>) -> HttpResponse {
     traffic_replace(Traffic {
         from: user_to_forgive.into_inner(),
         amount: 0.into(),

--- a/rita_common/src/dashboard/development.rs
+++ b/rita_common/src/dashboard/development.rs
@@ -15,13 +15,13 @@ use settings::RitaCommonSettings;
 use std::path::Path;
 
 #[cfg(not(feature = "development"))]
-pub fn wipe(_req: HttpRequest) -> HttpResponse {
+pub async fn wipe(_req: HttpRequest) -> HttpResponse {
     // This is returned on production builds.
     HttpResponse::NotFound().finish()
 }
 
 #[cfg(feature = "development")]
-pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
+pub async fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     let mut network_settings = SETTING.get_network_mut();
 
     // Clean up existing WG interfaces

--- a/rita_common/src/dashboard/nickname.rs
+++ b/rita_common/src/dashboard/nickname.rs
@@ -3,7 +3,7 @@ use arrayvec::ArrayString;
 
 use crate::RitaCommonError;
 
-pub fn get_nickname(_req: HttpRequest) -> HttpResponse {
+pub async fn get_nickname(_req: HttpRequest) -> HttpResponse {
     let nick = settings::get_rita_common().network.nickname;
 
     if let Some(nick) = nick {
@@ -21,7 +21,7 @@ pub struct Nickname {
     nickname: String,
 }
 
-pub fn set_nickname(nickname: Json<Nickname>) -> HttpResponse {
+pub async fn set_nickname(nickname: Json<Nickname>) -> HttpResponse {
     let new_nick = &nickname.nickname;
     match ArrayString::<32>::from(new_nick) {
         Ok(new) => {

--- a/rita_common/src/dashboard/own_info.rs
+++ b/rita_common/src/dashboard/own_info.rs
@@ -24,7 +24,7 @@ pub struct OwnInfo {
     pub client_can_use_free_tier: bool,
 }
 
-pub fn get_own_info(_req: HttpRequest) -> HttpResponse {
+pub async fn get_own_info(_req: HttpRequest) -> HttpResponse {
     debug!("Get own info endpoint hit!");
     let payment_settings = settings::get_rita_common().payment;
     let eth_address = payment_settings.eth_address.unwrap();

--- a/rita_common/src/dashboard/settings.rs
+++ b/rita_common/src/dashboard/settings.rs
@@ -1,6 +1,6 @@
 use actix_web_async::{http::StatusCode, web::Json, HttpRequest, HttpResponse};
 
-pub fn get_settings(_req: HttpRequest) -> HttpResponse {
+pub async fn get_settings(_req: HttpRequest) -> HttpResponse {
     debug!("Get settings endpoint hit!");
     match settings::get_config_json() {
         Ok(a) => HttpResponse::Ok().json(a),
@@ -9,7 +9,7 @@ pub fn get_settings(_req: HttpRequest) -> HttpResponse {
     }
 }
 
-pub fn set_settings(new_settings: Json<serde_json::Value>) -> HttpResponse {
+pub async fn set_settings(new_settings: Json<serde_json::Value>) -> HttpResponse {
     debug!("Set settings endpoint hit!");
     if let Err(e) = settings::merge_config_json(new_settings.into_inner()) {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)

--- a/rita_common/src/dashboard/token_bridge.rs
+++ b/rita_common/src/dashboard/token_bridge.rs
@@ -1,7 +1,7 @@
 use crate::token_bridge::get_bridge_status as get_status;
 use actix_web_async::{HttpRequest, HttpResponse};
 
-pub fn get_bridge_status(_req: HttpRequest) -> HttpResponse {
+pub async fn get_bridge_status(_req: HttpRequest) -> HttpResponse {
     trace!("/token_bridge/status hit");
     HttpResponse::Ok().json(get_status())
 }

--- a/rita_common/src/dashboard/usage.rs
+++ b/rita_common/src/dashboard/usage.rs
@@ -2,7 +2,7 @@ use crate::usage_tracker::get_payments_data;
 use ::actix_web_async::HttpRequest;
 use actix_web_async::HttpResponse;
 
-pub fn get_payments(_req: HttpRequest) -> HttpResponse {
+pub async fn get_payments(_req: HttpRequest) -> HttpResponse {
     trace!("/usage/relay hit");
 
     HttpResponse::Ok().json(get_payments_data())

--- a/rita_common/src/dashboard/wallet.rs
+++ b/rita_common/src/dashboard/wallet.rs
@@ -74,11 +74,11 @@ fn withdraw_handler(address: Address, amount: Option<Uint256>) -> HttpResponse {
     }
 }
 
-pub fn withdraw(path: Path<(Address, Uint256)>) -> HttpResponse {
+pub async fn withdraw(path: Path<(Address, Uint256)>) -> HttpResponse {
     withdraw_handler(path.0, Some(path.1.clone()))
 }
 
-pub fn withdraw_all(path: Path<Address>) -> HttpResponse {
+pub async fn withdraw_all(path: Path<Address>) -> HttpResponse {
     let address = path.into_inner();
     debug!("/withdraw_all/{} hit", address);
     withdraw_handler(address, None)

--- a/rita_common/src/dashboard/wg_key.rs
+++ b/rita_common/src/dashboard/wg_key.rs
@@ -3,7 +3,7 @@ use actix_web_async::{HttpRequest, HttpResponse};
 
 use crate::RitaCommonError;
 
-pub fn get_wg_public_key(_req: HttpRequest) -> HttpResponse {
+pub async fn get_wg_public_key(_req: HttpRequest) -> HttpResponse {
     let wg_public_key = settings::get_rita_common().network.wg_public_key;
 
     if let Some(wg_public_key) = wg_public_key {

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -15,8 +15,8 @@ althea_kernel_interface = { path = "../althea_kernel_interface" }
 althea_types = { path = "../althea_types" }
 settings = { path = "../settings" }
 babel_monitor = { path = "../babel_monitor" }
-actix-async = { package = "actix", version = "0.12"}
-awc = "3.0.0-beta.18"
+actix-async = { package = "actix", version = "0.13"}
+awc = "3.0.0-beta.21"
 handlebars = "4.0"
 rand = "0.8.0"
 lazy_static = "1.4"
@@ -33,6 +33,6 @@ arrayvec = {version= "0.7", features = ["serde"]}
 log = { version = "0.4", features = ["release_max_level_info"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 exit_db = { path = "../exit_db" }
-actix-web-async = {package="actix-web", version = "4.0.0-beta.8", default_features = false, features= ["openssl"] }
+actix-web-async = {package="actix-web", version = "4.0.1", default_features = false, features= ["openssl"] }
 diesel = { version = "1.4", features = ["postgres", "r2d2"] }
 [features]

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -181,7 +181,7 @@ pub async fn secure_setup_request(
     }
 }
 
-pub fn secure_status_request(request: Json<EncryptedExitClientIdentity>) -> HttpResponse {
+pub async fn secure_status_request(request: Json<EncryptedExitClientIdentity>) -> HttpResponse {
     let our_secretkey: WgKey = *EXIT_WG_PRIVATE_KEY;
     let our_secretkey = our_secretkey.into();
 
@@ -223,7 +223,7 @@ pub fn secure_status_request(request: Json<EncryptedExitClientIdentity>) -> Http
     ))
 }
 
-pub fn get_exit_info_http(_req: HttpRequest) -> HttpResponse {
+pub async fn get_exit_info_http(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(ExitState::GotInfo {
         general_details: get_exit_info(),
         message: "Got info successfully".to_string(),
@@ -236,7 +236,7 @@ pub fn get_exit_info_http(_req: HttpRequest) -> HttpResponse {
 /// which means packet loss simply resolves to overpayment, but the exit is being paid for uploaded traffic
 /// (the clients download traffic) which breaks this assumption
 /// TODO secure this endpoint with libsodium
-pub fn get_client_debt(client: Json<Identity>) -> HttpResponse {
+pub async fn get_client_debt(client: Json<Identity>) -> HttpResponse {
     let client = client.into_inner();
     let neg_one: i32 = -1;
     let neg_one = Int256::from(neg_one);
@@ -294,13 +294,13 @@ pub fn get_client_debt(client: Json<Identity>) -> HttpResponse {
 }
 
 #[cfg(not(feature = "development"))]
-pub fn nuke_db(_req: HttpRequest) -> HttpResponse {
+pub async fn nuke_db(_req: HttpRequest) -> HttpResponse {
     // This is returned on production builds.
     HttpResponse::NotFound().finish()
 }
 
 #[cfg(feature = "development")]
-pub fn nuke_db(_req: HttpRequest) -> HttpResponse {
+pub async fn nuke_db(_req: HttpRequest) -> HttpResponse {
     use crate::truncate_db_tables;
 
     trace!("nuke_db: Truncating all data from the database");


### PR DESCRIPTION
This patch updates our dependency tree for the newly released Actix
4.0.1, previously we have been using beta releases of this version.

The big change required by this update is that all endpoints need to be
tagged 'async' even if they never await.

awc is still in beta, so the beta version has been upgraded here as
well.