### PR TITLE
Creating stripped binary by adding strip to Cargo.toml

### DIFF
--- a/rita_bin/Cargo.toml
+++ b/rita_bin/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 license = "Apache-2.0"
 build = "build.rs"
 
+[profile.release]
+strip = "true"
+
 [[bin]]
 name = "rita_exit"
 path = "src/exit.rs"
@@ -60,3 +63,4 @@ dev_env = []
 development = ["rita_common/dash_debug","rita_client/operator_debug"]
 # Op tools dev environement
 optools_dev_env = ["rita_client/dev_env"]
+


### PR DESCRIPTION
Simple addition to Cargo.toml to strip unnecessary information like debuginfo
from binaries to make it smaller.