### PR TITLE
Removed migration code and old exit member struct and instances

### DIFF
--- a/rita_client/src/exit_manager/exit_switcher.rs
+++ b/rita_client/src/exit_manager/exit_switcher.rs
@@ -1109,7 +1109,6 @@ mod tests {
         let path = "./src/exit_manager/config_in_use.toml".to_string();
         let settings = RitaClientSettings::new(&path).unwrap();
 
-        println!("Old Settings: {:#?}", settings.exit_client.old_exits);
         println!("\n\n\n\nNew Settings: {:#?}", settings.exit_client.exits);
     }
 


### PR DESCRIPTION
The config has not been updated in the firmware repo and does this
automatically upon first boot. This means the old exit code is no
longer needed. It's not necessary to run every time on first boot,
so deleting this code is useful.