### PR TITLE
Adding sequence number to contact info to enable editing from ops tools

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -140,6 +140,8 @@ pub struct ExitRegistrationDetails {
     pub phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub phone_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sequence_number: Option<u32>,
 }
 
 /// This is the state an exit can be in
@@ -453,6 +455,8 @@ pub struct OperatorUpdateMessage {
     /// settings for the device bandwidth shaper
     #[serde(default = "default_shaper_settings")]
     pub shaper_settings: ShaperSettings,
+    /// Updated contact info from ops tools
+    pub contact_info: Option<ContactType>,
 }
 
 /// Settings for the bandwidth shaper

--- a/rita_client/src/dashboard/installation_details.rs
+++ b/rita_client/src/dashboard/installation_details.rs
@@ -37,15 +37,23 @@ pub async fn set_installation_details(req: Json<InstallationDetailsPost>) -> Htt
             (Ok(p), Ok(e)) => ContactType::Both {
                 number: p,
                 email: e,
+                // initialize sequence with 0
+                sequence_number: Some(0),
             },
             (_, _) => return HttpResponse::BadRequest().finish(),
         },
         (None, Some(email)) => match email.parse() {
-            Ok(e) => ContactType::Email { email: e },
+            Ok(e) => ContactType::Email {
+                email: e,
+                sequence_number: Some(0),
+            },
             Err(_e) => return HttpResponse::BadRequest().finish(),
         },
         (Some(phone), None) => match phone.parse() {
-            Ok(p) => ContactType::Phone { number: p },
+            Ok(p) => ContactType::Phone {
+                number: p,
+                sequence_number: Some(0),
+            },
             Err(_e) => return HttpResponse::BadRequest().finish(),
         },
     };

--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -399,6 +399,7 @@ pub async fn exit_setup_request(exit: String, code: Option<String>) -> Result<()
                         email_code: None,
                         phone: None,
                         phone_code: None,
+                        sequence_number: None,
                     }
                 } else {
                     return Err(RitaClientError::MiscStringError(


### PR DESCRIPTION
This sequence number is keeping track of the most recently updated version
of a router's user contact info. Editing it either from the router or from
ops tools will increment it and ops tools will display the most recent edit.