### PR TITLE
Fix Beta19 gateway behaivor

### DIFF
--- a/integration-tests/integration-test-script/rita.py
+++ b/integration-tests/integration-test-script/rita.py
@@ -86,7 +86,7 @@ SPEED = int(os.getenv('SPEEDTEST_THROUGHPUT'))
 TEST_PASSES = True
 
 EXIT_SETTINGS = {
-    "exits": {
+    "new_exits": {
         "exit_a": {
             "subnet": "fd00::5/128",
             "id": {
@@ -109,7 +109,7 @@ EXIT_SETTINGS = {
 }
 
 EXIT_SELECT = {
-    "exits": {
+    "new_exits": {
         "exit_a": {
             "state": "Registering",
         }

--- a/integration-tests/integration-test-script/world.py
+++ b/integration-tests/integration-test-script/world.py
@@ -146,12 +146,12 @@ class World:
         self.exit_price = get_rita_settings(
             self.exit_id)["exit_network"]["exit_price"]
 
-        EXIT_SETTINGS["exits"]["exit_a"]["wg_public_key"] = get_rita_settings(
+        EXIT_SETTINGS["new_exits"]["exit_a"]["wg_public_key"] = get_rita_settings(
             self.exit_id)["exit_network"]["wg_public_key"]
-        EXIT_SETTINGS["exits"]["exit_a"]["id"]["wg_public_key"] = get_rita_settings(
+        EXIT_SETTINGS["new_exits"]["exit_a"]["id"]["wg_public_key"] = get_rita_settings(
             self.exit_id)["exit_network"]["wg_public_key"]
-        EXIT_SETTINGS["exits"]["exit_a"]["payment"] = {}
-        EXIT_SETTINGS["exits"]["exit_a"]["payment"]["eth_address"] = get_rita_settings(
+        EXIT_SETTINGS["new_exits"]["exit_a"]["payment"] = {}
+        EXIT_SETTINGS["new_exits"]["exit_a"]["payment"]["eth_address"] = get_rita_settings(
             self.exit_id)["payment"]["eth_address"]
             
 

--- a/rita_common/src/hello_handler/mod.rs
+++ b/rita_common/src/hello_handler/mod.rs
@@ -26,11 +26,20 @@ pub struct Hello {
 pub async fn handle_hello(msg: Hello) {
     trace!("Sending Hello {:?}", msg);
 
-    let endpoint = format!(
-        "http://[{}]:{}/hello",
-        msg.to.contact_socket.ip(),
-        msg.to.contact_socket.port()
-    );
+    // ipv6 addresses need the [] bracket format, ipv4 address literals do not
+    let endpoint = if msg.to.contact_socket.is_ipv4() {
+        format!(
+            "http://{}:{}/hello",
+            msg.to.contact_socket.ip(),
+            msg.to.contact_socket.port()
+        )
+    } else {
+        format!(
+            "http://[{}]:{}/hello",
+            msg.to.contact_socket.ip(),
+            msg.to.contact_socket.port()
+        )
+    };
 
     let client = awc::Client::default();
     info!("Sending hello request to manual peer: {}", endpoint);

--- a/rita_common/src/peer_listener/mod.rs
+++ b/rita_common/src/peer_listener/mod.rs
@@ -89,6 +89,7 @@ impl PeerListener {
     }
 }
 
+/// Creates a listen interface on all interfaces in the peer_interfaces hashmap.
 fn listen_to_available_ifaces(peer_listener: &mut PeerListener) {
     let interfaces = settings::get_rita_common().network.peer_interfaces;
     let iface_list = interfaces;
@@ -106,6 +107,8 @@ fn listen_to_available_ifaces(peer_listener: &mut PeerListener) {
     }
 }
 
+/// Ticks the peer listener module sending ImHere messages and receiving Hello messages from all
+/// peers over UDP
 pub fn peerlistener_tick() {
     trace!("Starting PeerListener tick!");
 
@@ -198,6 +201,7 @@ impl ListenInterface {
     }
 }
 
+/// send UDP ImHere messages over IPV6 link local
 fn send_im_here(interfaces: &mut HashMap<String, ListenInterface>) {
     trace!("About to send ImHere");
     for obj in interfaces.iter_mut() {
@@ -218,6 +222,7 @@ fn send_im_here(interfaces: &mut HashMap<String, ListenInterface>) {
     }
 }
 
+/// receive UDP ImHere messages over IPV6 link local
 fn receive_im_here(
     interfaces: &mut HashMap<String, ListenInterface>,
 ) -> (HashMap<IpAddr, Peer>, HashMap<SocketAddr, String>) {
@@ -279,6 +284,7 @@ fn receive_im_here(
     (output, interface_map)
 }
 
+/// Send UDP hello message over IPV6
 pub fn send_hello(msg: &Hello, socket: &UdpSocket, send_addr: SocketAddr, sender_wgport: u16) {
     trace!("Sending a Hello message");
 
@@ -294,6 +300,7 @@ pub fn send_hello(msg: &Hello, socket: &UdpSocket, send_addr: SocketAddr, sender
     }
 }
 
+/// receive UDP hello messages over IPV6 link local ports
 pub fn receive_hello(writer: &mut PeerListener) {
     trace!("Dequeing Hello");
     for obj in writer.interfaces.iter_mut() {

--- a/rita_common/src/rita_loop/fast_loop.rs
+++ b/rita_common/src/rita_loop/fast_loop.rs
@@ -10,10 +10,9 @@ use crate::peer_listener::get_peers;
 use crate::peer_listener::peerlistener_tick;
 use crate::tm_trigger_gc;
 use crate::traffic_watcher::watch;
+use crate::tunnel_manager::contact_peers::tm_contact_peers;
 use crate::tunnel_manager::gc::TriggerGc;
-use crate::tunnel_manager::tm_contact_peers;
 use crate::tunnel_manager::tm_get_neighbors;
-use crate::tunnel_manager::PeersToContact;
 use crate::update_neighbor_status;
 
 use actix_async::System as AsyncSystem;
@@ -182,10 +181,8 @@ pub fn peer_discovery_loop() {
                         start.elapsed().subsec_millis(),
                     );
 
-                    let peers = get_peers();
-
-                    //Contact peers
-                    tm_contact_peers(PeersToContact::new(peers)).await;
+                    // Contact manual peers
+                    tm_contact_peers(get_peers()).await;
                 });
 
                 // sleep until it has been FAST_LOOP_SPEED seconds from start, whenever that may be

--- a/rita_common/src/tunnel_manager/contact_peers.rs
+++ b/rita_common/src/tunnel_manager/contact_peers.rs
@@ -1,0 +1,214 @@
+//! This file contains http hello sending and handling functions, these are used exclusively for
+//! manual peers, or peers that are not on the local network and require hello's routed over networks that
+//! are not althea, such as the larger internet. While manual peers can be used for any peer to peer connection
+//! it's mostly used for Gateways to reach exits and bridge them into the local babel mesh network, allowing clients
+//! to reach them and send traffic to the internet.
+
+use crate::hello_handler::handle_hello;
+use crate::hello_handler::Hello;
+use crate::peer_listener::Hello as NewHello;
+use crate::peer_listener::PeerListener;
+use crate::peer_listener::PEER_LISTENER;
+use crate::peer_listener::{send_hello, Peer};
+use crate::rita_loop::is_gateway;
+use crate::tunnel_manager::tm_get_port;
+use crate::RitaCommonError;
+use crate::KI;
+use althea_types::LocalIdentity;
+use std::collections::HashMap;
+use std::net::ToSocketAddrs;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+
+/// Resolves a hostname and sends a hello to the resulting IP, this function may block, this is the
+/// primary reason peer discovery is given it's own thread currently.
+pub async fn tm_neighbor_inquiry_hostname(their_hostname: String) -> Result<(), RitaCommonError> {
+    info!("neighbor_inquiry_hostname {}", their_hostname);
+    let network_settings = settings::get_rita_common().network;
+    let is_gateway = is_gateway();
+    let rita_hello_port = network_settings.rita_hello_port;
+
+    let our_port = tm_get_port();
+
+    // note this may block and should only be called in the peer discovery loop where blocking is accounted for
+    // note we add the hello port to make this a valid socket address which must include one, any port could be used here
+    let res = format!("{}:{}", their_hostname, rita_hello_port).to_socket_addrs();
+    match res {
+        Ok(dnsresult) => {
+            let url = format!("http://[{}]:{}/hello", their_hostname, rita_hello_port);
+            info!("Saying hostname hello to: {:?} at ip {:?}", url, dnsresult);
+            if dnsresult.clone().next().is_some() && is_gateway {
+                // dns records may have many ip's if we get multiple it's a load
+                // balanced exit and we need to create tunnels to all of them
+                for dns_socket in dnsresult {
+                    let their_ip = dns_socket.ip();
+                    let socket = SocketAddr::new(their_ip, rita_hello_port);
+                    let man_peer = Peer {
+                        ifidx: 0,
+                        contact_socket: socket,
+                    };
+                    let res = contact_manual_peer(&man_peer, our_port).await;
+                    if res.is_err() {
+                        warn!("Contact neighbor failed with {:?}", res);
+                    }
+                }
+            } else {
+                trace!(
+                    "We're not a gateway or we got a zero length dns response: {:?}",
+                    dnsresult
+                );
+            }
+        }
+        Err(e) => {
+            warn!("DNS resolution failed with {:?} for {}", e, their_hostname);
+        }
+    }
+    Ok(())
+}
+
+/// Contacts one neighbor with our LocalIdentity to get their LocalIdentity and wireguard tunnel
+/// interface name. Sends a Hello over udp, or http if its a manual peer
+pub async fn tm_neighbor_inquiry(
+    peer: &Peer,
+    is_manual_peer: bool,
+    peer_listener: &mut PeerListener,
+) -> Result<(), RitaCommonError> {
+    trace!("TunnelManager neigh inquiry for {:?}", peer);
+    let our_port = tm_get_port();
+
+    if is_manual_peer {
+        contact_manual_peer(peer, our_port).await
+    } else {
+        let iface_name = match peer_listener.interface_map.get(&peer.contact_socket) {
+            Some(a) => a,
+            None => {
+                return Err(RitaCommonError::MiscStringError(
+                    "No interface in the hashmap to send a message".to_string(),
+                ))
+            }
+        };
+        let udp_socket = match peer_listener.interfaces.get(iface_name) {
+            Some(a) => &a.linklocal_socket,
+            None => {
+                return Err(RitaCommonError::MiscStringError(
+                    "No udp socket present for given interface".to_string(),
+                ))
+            }
+        };
+        contact_neighbor(peer, our_port, udp_socket, peer.contact_socket).await
+    }
+}
+
+/// takes a list of peers to contact and dispatches UDP hello messages to peers discovered via IPv6 link local
+/// multicast peer discovery, also sends http hello messages to manual peers, only resolves manual peers with
+/// hostnames if the devices is detected to be a gateway.
+pub async fn tm_contact_peers(peers: HashMap<IpAddr, Peer>) {
+    let network_settings = settings::get_rita_common().network;
+    let manual_peers = network_settings.manual_peers.clone();
+    let is_gateway = is_gateway();
+    let rita_hello_port = network_settings.rita_hello_port;
+    drop(network_settings);
+    // Hold a lock on shared state until we finish sending all messages. This prevents a race condition
+    // where the hashmaps get cleared out during subsequent ticks
+    info!("TunnelManager contacting peers");
+    let writer = &mut *PEER_LISTENER.write().unwrap();
+
+    for (_, peer) in peers.iter() {
+        info!("contacting peer found by UDP {:?}", peer);
+        let res = tm_neighbor_inquiry(peer, false, writer).await;
+        if res.is_err() {
+            warn!("Neighbor inqury for {:?} failed! with {:?}", peer, res);
+        }
+    }
+    for manual_peer in manual_peers.iter() {
+        info!("contacting manual peer {:?}", manual_peer);
+        let ip = manual_peer.parse::<IpAddr>();
+        match ip {
+            Ok(ip) => {
+                let socket = SocketAddr::new(ip, rita_hello_port);
+                let man_peer = Peer {
+                    ifidx: 0,
+                    contact_socket: socket,
+                };
+                let res = tm_neighbor_inquiry(&man_peer, true, writer).await;
+                if res.is_err() {
+                    warn!(
+                        "Neighbor inqury for {:?} failed with: {:?}",
+                        manual_peer, res
+                    );
+                }
+            }
+            Err(_) => {
+                // Do not contact manual peers on the internet if we are not a gateway
+                // it will just fill the logs with failed dns resolution attempts or result
+                // in bad behavior, we do allow the addressing of direct ip address gateways
+                // for the special case that the user is attempting some special behavior
+                if is_gateway {
+                    let res = tm_neighbor_inquiry_hostname(manual_peer.to_string()).await;
+                    if res.is_err() {
+                        warn!(
+                            "Neighbor inqury for {:?} failed with: {:?}",
+                            manual_peer, res
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Sets out to contacts a local mesh neighbor, takes a speculative port (only assigned if the neighbor
+/// responds successfully). This function is used for mesh peers
+async fn contact_neighbor(
+    peer: &Peer,
+    our_port: u16,
+    socket: &UdpSocket,
+    send_addr: SocketAddr,
+) -> Result<(), RitaCommonError> {
+    let new_msg = NewHello {
+        my_id: LocalIdentity {
+            global: settings::get_rita_common().get_identity().ok_or_else(|| {
+                RitaCommonError::MiscStringError("Identity has no mesh IP ready yet".to_string())
+            })?,
+            wg_port: our_port,
+            have_tunnel: None,
+        },
+        to: *peer,
+        response: false,
+    };
+
+    // new send_hello call using udp socket
+    // We do not need the old http hello except for exits, which are called as manual peers
+    send_hello(&new_msg, socket, send_addr, our_port);
+
+    Ok(())
+}
+
+/// Uses Hello Handler to send a Hello over http. Takes a speculative port (only assigned
+/// if neighbor responds successfully)
+async fn contact_manual_peer(peer: &Peer, our_port: u16) -> Result<(), RitaCommonError> {
+    let mut settings = settings::get_rita_common();
+    let changed = KI.manual_peers_route(
+        &peer.contact_socket.ip(),
+        &mut settings.network.last_default_route,
+    )?;
+
+    let msg = Hello {
+        my_id: LocalIdentity {
+            global: settings.get_identity().ok_or_else(|| {
+                RitaCommonError::MiscStringError("Identity has no mesh IP ready yet".to_string())
+            })?,
+            wg_port: our_port,
+            have_tunnel: None,
+        },
+        to: *peer,
+    };
+
+    if changed {
+        settings::set_rita_common(settings);
+    }
+
+    //old hello manager over http
+    handle_hello(msg).await;
+
+    Ok(())
+}


### PR DESCRIPTION
Copying in each individual commit message for easy review.

```
commit 34a1f01301a06f8fae99a41bac445018726939d2 (HEAD -> jkilpatr/fix-beta-19-gateway, public/jkilpatr/fix-beta-19-gateway)
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:42:41 2022 -0400

    Modify integration tests to work with exits rename
    
    In order not to conflict with the existing exits field in the config we
    have to 'rename' the field as new_exits, this means our /settings
    endpoint that merges raw json with the config does not work the same way
    in the integration tests. This patch changes the integration tests to
    use the new_exits field name.
    
    This can be reverted once we finish removing the existing 'exits' field
    which will be done automatically the first time a router saves the
    config. From there we can use 'alias' in the following release and roll
    back this change.

commit 28fa23ceb182283bcce96c6348aa46fec7414333
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:15:32 2022 -0400

    Peer discovery functions should not be members of TunnelManager
    
    In the Actix Actor paradigm the Tunnel manager struct contained all the
    state of the TunnelManager actor and any function that needed to
    interact with this state had to be a member function. Now that we have
    moved to async/await and our TunnelManager struct is held behind a
    simple lock rather than the Actor message queue this results in a
    deadlock.
    
    Previously when we recieved a response from a hello message we would
    send a call back message, now we can perform the callback within the
    same async call stack as sending the hello if the first place. Since
    sinding the hello requires access to the ports list, it was a
    TunnelManager member function. This results in an impossible to resolve
    deadlock where sending and recieving http hellos can not function.
    
    This patch resolves the issue by removing the peer discovery functions
    as TunnelManager member functions, resolving the deadlock.
    
    We also move these peer discovery functions into their own file and make
    a slight modification to the to_socket_addrs() use to ensure domains
    resolve.

commit eeb2e0931033283da512e75a69616b068a8d856d
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:12:48 2022 -0400

    Modify manual peers route to return if a modification is made
    
    I don't really like the mutable reference pattern we've got going here
    but tearing it out is pretty disruptive. In order to optimize our use of
    the settings lock this function now returns true if it actually makes a
    change, allowing us to skip updating the settings if they have not been
    modified.

commit 0857ae1b8e44f7da11956a75aedbbf612187dc4a
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:11:01 2022 -0400

    Add some function comments to PeerListener
    
    My goal here to help the reader easily understand both the http and udp
    peer discovery flow.

commit c816e94538abb4f2f79f6cb44be2e4b92813ba49
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:09:48 2022 -0400

    Provide helper functions for last tunnel manager GC
    
    This is a trivial re-phrasing of the same functionality that is slightly
    cleaner in terms of making sure the lock does not get held by accident.

commit 768b57a04da9b3aeeebb56eeef5fe6874b438556
Author: Justin Kilpatrick <justin@althea.net>
Date:   Wed Mar 23 16:03:54 2022 -0400

    Only use bracket format on ipv6 manual peers
    
    Previously the actix http library handled brackets around ipv4
    addresses, the latest version no longer handles this transparently and
    we now have to check our address formatting depending on if we have an
    ipv4 or v6 address to send a http hello to.

```