### PR TITLE
disables hardware info collection when logging disabled

### DIFF
--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -167,12 +167,16 @@ async fn checkin() {
         neighbor_info.push(status);
     }
 
-    let hardware_info = match get_hardware_info(rita_client.network.device) {
-        Ok(info) => Some(info),
-        Err(e) => {
-            error!("Failed to get hardware info with {:?}", e);
-            None
-        }
+    // disable hardware info sending if logging is disabled
+    let hardware_info = match logging_enabled {
+        true => match get_hardware_info(rita_client.network.device) {
+            Ok(info) => Some(info),
+            Err(e) => {
+                error!("Failed to get hardware info with {:?}", e);
+                None
+            }
+        },
+        false => None,
     };
 
     let client = awc::Client::default();


### PR DESCRIPTION
https://trello.com/c/qEjsRWzW/442-disable-wifi-info-collection-if-logging-is-disabled
