### PR TITLE
Remove selectedId field from config

### DIFF
--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -1,6 +1,6 @@
 //! The Exit info endpoint gathers infromation about exit status and presents it to the dashbaord.
 
-use crate::exit_manager::exit_setup_request;
+use crate::exit_manager::{exit_setup_request, get_current_selected_exit};
 use crate::RitaClientError;
 use actix_web_async::http::StatusCode;
 use actix_web_async::{web::Json, web::Path, HttpRequest, HttpResponse};
@@ -66,10 +66,7 @@ pub fn dashboard_get_exit_info() -> Result<Vec<ExitInfo>, RitaClientError> {
                     for exit in exit_client.exits.clone().into_iter() {
                         let selected = is_selected(&exit.1, current_exit);
                         let have_route = do_we_have_route(
-                            &exit
-                                .1
-                                .selected_exit
-                                .selected_id
+                            &get_current_selected_exit()
                                 .expect("Expected exit ip here, but none present"),
                             &route_table_sample,
                         )?;
@@ -78,10 +75,7 @@ pub fn dashboard_get_exit_info() -> Result<Vec<ExitInfo>, RitaClientError> {
                         // to expect the pings to work before issuing them.
                         let reachable = if have_route {
                             KI.ping_check(
-                                &exit
-                                    .1
-                                    .selected_exit
-                                    .selected_id
+                                &get_current_selected_exit()
                                     .expect("Expected exit ip here, but none present"),
                                 EXIT_PING_TIMEOUT,
                             )?

--- a/rita_client/src/dashboard/neighbors.rs
+++ b/rita_client/src/dashboard/neighbors.rs
@@ -13,6 +13,7 @@ use rita_common::tunnel_manager::{tm_get_neighbors, Neighbor};
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::exit_manager::get_current_selected_exit;
 use crate::RitaClientError;
 
 const BABEL_TIMEOUT: Duration = Duration::from_secs(5);
@@ -86,9 +87,6 @@ fn generate_neighbors_list(
     debts: HashMap<Identity, (NodeDebtData, Neighbor)>,
 ) -> Vec<NodeInfo> {
     let mut output = Vec::new();
-    let rita_client = settings::get_rita_client();
-    let exit_client = rita_client.exit_client;
-    let current_exit = exit_client.get_current_exit();
 
     for (identity, (debt_info, neigh)) in debts.iter() {
         let nickname = match identity.nickname {
@@ -108,10 +106,9 @@ fn generate_neighbors_list(
         }
         let neigh_route = maybe_route.unwrap();
 
-        let tup = (current_exit, stats.get(&neigh_route.iface));
-        if let (Some(current_exit), Some(stats_entry)) = tup {
-            if current_exit.selected_exit.selected_id.is_some() {
-                let exit_ip = current_exit.selected_exit.selected_id.unwrap();
+        if let Some(stats_entry) = stats.get(&neigh_route.iface) {
+            if get_current_selected_exit().is_some() {
+                let exit_ip = get_current_selected_exit().unwrap();
                 let maybe_exit_route =
                     get_route_via_neigh(identity.mesh_ip, exit_ip, &route_table_sample);
 

--- a/rita_client/src/heartbeat/mod.rs
+++ b/rita_client/src/heartbeat/mod.rs
@@ -52,6 +52,8 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 
+use crate::exit_manager::get_current_selected_exit;
+
 pub const HEARTBEAT_LOOP_SPEED: u64 = 5;
 
 mod dummy;
@@ -253,12 +255,8 @@ fn send_udp_heartbeat() {
 }
 
 fn get_selected_exit_route(route_dump: &[RouteLegacy]) -> Result<RouteLegacy, BabelMonitorError> {
-    let rita_client = settings::get_rita_client();
-    let exit_client = rita_client.exit_client;
-    let exit_mesh_ip = if let Some(e) = exit_client.get_current_exit() {
-        e.selected_exit
-            .selected_id
-            .expect("Expected Exit ip, none present")
+    let exit_mesh_ip = if let Some(e) = get_current_selected_exit() {
+        e
     } else {
         return Err(BabelMonitorError::MiscStringError("No Exit".to_string()));
     };

--- a/rita_client/src/rita_loop/mod.rs
+++ b/rita_client/src/rita_loop/mod.rs
@@ -5,6 +5,7 @@
 //! tunnel if the signup was successful on the selected exit.
 
 use crate::exit_manager::exit_manager_tick;
+use crate::exit_manager::get_current_selected_exit;
 use crate::heartbeat::send_heartbeat_loop;
 use crate::heartbeat::HEARTBEAT_SERVER_KEY;
 use crate::light_client_manager::lcm_watch;
@@ -156,10 +157,7 @@ fn check_for_gateway_client_billing_corner_case() {
                 // we have a neighbor who is also our selected exit!
                 // wg_key excluded due to multihomed exits having a different one
                 if neigh.identity.global.mesh_ip
-                    == exit
-                        .selected_exit
-                        .selected_id
-                        .expect("Expected exit ip, none present")
+                    == get_current_selected_exit().expect("Expected exit ip, none present")
                     && neigh.identity.global.eth_address == exit.eth_address
                 {
                     info!("We are a gateway client");

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -40,9 +40,6 @@ pub struct ExitServer {
     //field added for serde config writing
     pub subnet_len: u8,
 
-    // Struct containing information of current exit and tracking exit, if connected to one
-    pub selected_exit: SelectedExit,
-
     // eth address of Selected exit
     pub eth_address: Address,
 
@@ -167,14 +164,6 @@ impl RitaClientSettings {
         set_rita_client(settings.clone());
 
         Ok(settings)
-    }
-
-    pub fn get_exit_id(&self) -> Option<IpAddr> {
-        self.exit_client
-            .get_current_exit()
-            .as_ref()?
-            .selected_exit
-            .selected_id
     }
 }
 


### PR DESCRIPTION
Now with the new exit subnetting feature, having persistant-keepalives from every exit
caused an issue where the router would renegotiate a tunnel without that exit being selected.
This was not an issue previously where all exits shared an ip
Removing this ensures keepalives to be sent only from the client side to the exit they are connected to