### PR TITLE
 Do not update balance if blockheight has been rolled back 

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -286,7 +286,7 @@ impl CommandRunner for TestCommandRunner {
             args_owned.push((*a).to_string())
         }
 
-        (&mut *self.run_command.lock().unwrap())(program.to_string(), args_owned)
+        (*self.run_command.lock().unwrap())(program.to_string(), args_owned)
     }
 
     fn set_mock(&self, mock: CommandFunction) {

--- a/rita_client/src/exit_manager/exit_switcher.rs
+++ b/rita_client/src/exit_manager/exit_switcher.rs
@@ -292,7 +292,7 @@ fn set_exit_state(
     rita_client_exit_ser_ref: &mut ExitServer,
     exit_code: ExitSwitchingCode,
     exit_metrics: ExitMetrics,
-    metric_vec: &mut Vec<u16>,
+    metric_vec: &mut [u16],
 ) -> Result<IpAddr, RitaClientError> {
     match exit_code {
         // we get this code when the exit is not setup, meaning it should not reach this else statement in the first place.
@@ -320,7 +320,7 @@ fn set_exit_state(
                 .selected_id_degradation
                 .is_none()
             {
-                let average_metric = calculate_average(metric_vec.clone());
+                let average_metric = calculate_average(metric_vec.to_owned());
                 // We set degradation value = RelU(average_metric val - our_advertised_metric). Since we know tracking_exit == current_exit,
                 // We can use values in the vector.
                 rita_client_exit_ser_ref
@@ -669,14 +669,14 @@ fn reset_exit_tracking(exit_map: &mut HashMap<IpAddr, ExitTracker>) {
 /// reseting our tracking exit every tick, we continue with one exit, either B or C, unless one exit becomes significantly better than the other. This way
 /// we dont get stuck at exit A when there are better exits available.
 fn worth_switching_tracking_exit(
-    metric_vec: &mut Vec<u16>,
+    metric_vec: &mut [u16],
     best_ip: IpAddr,
     exit_map: &mut HashMap<IpAddr, ExitTracker>,
 ) -> bool {
     if metric_vec.is_empty() {
         return false;
     }
-    let avg_tracking_metric = calculate_average(metric_vec.clone());
+    let avg_tracking_metric = calculate_average(metric_vec.to_owned());
 
     let exit_tracker = exit_map
         .get(&best_ip)

--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -721,7 +721,7 @@ pub mod tests {
     use althea_types::Identity;
 
     /// gets a mutable reference tunnel from the list with the given index
-    fn get_mut_tunnel_by_ifidx(ifidx: u32, tunnels: &mut Vec<Tunnel>) -> Option<&mut Tunnel> {
+    fn get_mut_tunnel_by_ifidx(ifidx: u32, tunnels: &mut [Tunnel]) -> Option<&mut Tunnel> {
         for tunnel in tunnels.iter_mut() {
             if tunnel.listen_ifidx == ifidx {
                 return Some(tunnel);


### PR DESCRIPTION
In web30 0.18.3 we introduced a feature to check if a node is syncing
for balance checks.

The goal of this change was to get around issues where xdai nodes would
return old balances as they where syncing. It seems to have worked fine
during testing but this weekend we had an incident where many nodes
thought their balance was 0 due to a syncing node in the cluster. I
believe that this node must have been lying about syncing, returning
false when the eth_getSyncing endpoint was queried while it was in fact
very far behind the tip of the chain.

This patch adds another layer of protection, where the oracle keeps
track of the latest block it has seen and will refuse to update when
presented with older data. hopefully this is finally sufficient to
prevent issues.