### PR TITLE
Changed position of funciton that calls local exit ip initiaztion

### DIFF
--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -65,6 +65,7 @@ pub fn dashboard_get_exit_info() -> Result<Vec<ExitInfo>, RitaClientError> {
 
                     for exit in exit_client.exits.clone().into_iter() {
                         let selected = is_selected(&exit.1, current_exit);
+                        info!("Trying to get exit: {}", exit.0.clone());
                         let route_ip = match get_selected_exit(exit.0.clone()) {
                             Some(a) => a,
                             None => {


### PR DESCRIPTION
Previously the function initialize_selected_exit_list was called in a position that was unreachable. This moves it to the front
of the exit_manager_tick loop