### PR TITLE
Make opkg update commands more generic

### DIFF
--- a/althea_kernel_interface/src/opkg_feeds.rs
+++ b/althea_kernel_interface/src/opkg_feeds.rs
@@ -3,13 +3,12 @@ use crate::file_io::write_out;
 use crate::KernelInterfaceError as Error;
 
 pub static CUSTOMFEEDS: &str = "/etc/opkg/customfeeds.conf";
-static FEED_NAME: &str = "althea";
 
-pub fn get_release_feed(customfeeds: &str) -> Result<String, Error> {
+pub fn get_release_feed(customfeeds: &str, feed_name: &str) -> Result<String, Error> {
     let lines = get_lines(customfeeds)?;
     for line in lines.iter() {
         // there may be other custom feeds configured, if it's not althea skip it
-        if !line.contains(&FEED_NAME.to_string()) {
+        if !line.contains(feed_name) {
             continue;
         }
         return Ok(line.to_string());
@@ -17,11 +16,11 @@ pub fn get_release_feed(customfeeds: &str) -> Result<String, Error> {
     Err(Error::NoAltheaReleaseFeedFound)
 }
 
-pub fn set_release_feed(val: &str, customfeeds: &str) -> Result<(), Error> {
+pub fn set_release_feed(val: &str, feed_name: &str, customfeeds: &str) -> Result<(), Error> {
     let mut lines = get_lines(customfeeds)?;
 
     for line in lines.iter_mut() {
-        if line.contains(&FEED_NAME.to_string()) {
+        if line.contains(feed_name) {
             let src_line = val.to_string();
             let mut owned_string = "src/gz althea ".to_string().to_owned();
             owned_string.push_str(&src_line);
@@ -37,16 +36,16 @@ fn test_reading_feed() {
     let path = "../settings/customfeed.conf";
     assert_eq!(
         "src/gz althea www.dummyurl.com".to_string(),
-        get_release_feed(path).unwrap()
+        get_release_feed(path, "althea").unwrap()
     );
 }
 
 #[test]
 fn test_writing_feed() {
     let path = "../settings/customfeed.conf";
-    let _res = set_release_feed("www.dummyurl.com", path);
+    let _res = set_release_feed("www.dummyurl.com", "althea", path);
     assert_eq!(
         "src/gz althea www.dummyurl.com".to_string(),
-        get_release_feed(path).unwrap()
+        get_release_feed(path, "althea").unwrap()
     );
 }

--- a/althea_kernel_interface/src/upgrade.rs
+++ b/althea_kernel_interface/src/upgrade.rs
@@ -1,6 +1,9 @@
 use super::KernelInterface;
-use crate::KernelInterfaceError as Error;
-use althea_types::{OpkgCommand, OpkgCommandType, SysupgradeCommand};
+use crate::{
+    opkg_feeds::{get_release_feed, set_release_feed, CUSTOMFEEDS},
+    KernelInterfaceError as Error,
+};
+use althea_types::{OpkgCommand, SysupgradeCommand};
 use std::process::Output;
 
 impl dyn KernelInterface {
@@ -31,48 +34,74 @@ impl dyn KernelInterface {
     /// This function checks if the function provided is update or install. In case of install, for each of the packages
     /// present, the arguments given are applied and opkg install is run
     pub fn perform_opkg(&self, command: OpkgCommand) -> Result<Output, Error> {
-        match command.opkg_command {
-            OpkgCommandType::Update => {
-                if command.packages.is_none() {
-                    let mut args = command.arguments.unwrap_or_default();
-                    args.insert(0, "update".to_string());
-                    let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
-                    info!("Running command opkg with args: {:?}", args_ref);
-                    self.run_command("opkg", &args_ref)
-                } else {
-                    let mut res = Err(Error::RuntimeError(
-                        "No packages given to update".to_string(),
-                    ));
-                    for packet in command.packages.clone().unwrap() {
-                        let mut args = command.arguments.clone().unwrap_or_default();
-                        args.insert(0, packet);
-                        args.insert(0, "update".to_string());
-                        let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
-                        info!("Running command opkg with args: {:?}", args_ref);
-                        res = self.run_command("opkg", &args_ref);
-                        res.clone()?;
-                    }
-                    res
+        match command {
+            OpkgCommand::Install {
+                packages,
+                arguments,
+            } => {
+                let mut args = arguments;
+                args.insert(0, "install".to_string());
+                for package in packages {
+                    args.push(package);
                 }
+                info!("Running opkg install with args: {:?}", args);
+                let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
+                self.run_command("opkg", &args_ref)
             }
-            OpkgCommandType::Install => {
-                let mut res = Err(Error::RuntimeError(
-                    "No packages given to install".to_string(),
-                ));
-                if command.packages.is_none() {
-                    error!("No packages given to opkg install");
-                    return res;
+            OpkgCommand::Remove {
+                packages,
+                arguments,
+            } => {
+                let mut args = arguments;
+                args.insert(0, "remove".to_string());
+                for package in packages {
+                    args.push(package);
                 }
-                for packet in command.packages.clone().unwrap() {
-                    let mut args = command.arguments.clone().unwrap_or_default();
-                    args.insert(0, packet);
-                    args.insert(0, "install".to_string());
-                    let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
-                    info!("Running command opkg with args: {:?}", args_ref);
-                    res = self.run_command("opkg", &args_ref);
-                    res.clone()?;
+                info!("Running opkg remove with args: {:?}", args);
+                let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
+                self.run_command("opkg", &args_ref)
+            }
+            OpkgCommand::Update {
+                feed,
+                feed_name,
+                arguments,
+            } => {
+                handle_release_feed_update(feed, feed_name)?;
+                let mut args = arguments;
+                args.insert(0, "update".to_string());
+                info!("Running opkg update with args: {:?}", args);
+                let args_ref: Vec<&str> = args.iter().map(std::ops::Deref::deref).collect();
+                self.run_command("opkg", &args_ref)
+            }
+        }
+    }
+}
+
+// updates the release feed if and only if it actually results in a change, this does
+// produce a disk write, so we want to avoid it if possible
+fn handle_release_feed_update(new_feed: String, feed_name: String) -> Result<(), Error> {
+    match get_release_feed(CUSTOMFEEDS, &feed_name) {
+        // if there's an error getting the current release feed, try to set anyways
+        Err(_) => match set_release_feed(&new_feed, &feed_name, CUSTOMFEEDS) {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to set new release feed! {:?}", e);
+                Err(e)
+            }
+        },
+        // if we can successfully get the old release feed, check that we are
+        // actually changing it, then apply the change
+        Ok(old_feed) => {
+            if !old_feed.contains(&new_feed) {
+                match set_release_feed(&new_feed, &feed_name, CUSTOMFEEDS) {
+                    Ok(_) => Ok(()),
+                    Err(e) => {
+                        error!("Failed to set new release feed! {:?}", e);
+                        Err(e)
+                    }
                 }
-                res
+            } else {
+                Ok(())
             }
         }
     }

--- a/rita_client/src/dashboard/router.rs
+++ b/rita_client/src/dashboard/router.rs
@@ -1,4 +1,4 @@
-use crate::operator_update::updater::update_rita;
+use crate::operator_update::updater::update_system;
 use actix_web_async::{http::StatusCode, HttpRequest, HttpResponse};
 use althea_types::UpdateType;
 use rita_common::KI;
@@ -30,7 +30,7 @@ pub async fn update_router(_req: HttpRequest) -> HttpResponse {
         if reader.is_none() {
             return HttpResponse::Ok().json("No update instructions set, doing nothing");
         }
-        if let Err(e) = update_rita(reader.as_ref().unwrap().clone()) {
+        if let Err(e) = update_system(reader.as_ref().unwrap().clone()) {
             return HttpResponse::Ok()
                 .json(format!("Retrieved Error while performing update {}", e));
         }

--- a/rita_client/src/operator_update/updater.rs
+++ b/rita_client/src/operator_update/updater.rs
@@ -1,32 +1,21 @@
-use crate::operator_update::handle_release_feed_update;
 use althea_kernel_interface::KernelInterfaceError;
 use althea_types::UpdateType;
 use rita_common::KI;
-use std::process::Output;
 
-/// Updates rita by performing either a sysupgrade or opkg install
-pub fn update_rita(instruction: UpdateType) -> Result<Output, KernelInterfaceError> {
+/// Updates the system, including Rita and other packages by performing either a sysupgrade or opkg install
+pub fn update_system(instruction: UpdateType) -> Result<(), KernelInterfaceError> {
     if KI.is_openwrt() {
         match instruction {
-            UpdateType::Sysupgrade(command) => KI.perform_sysupgrade(command),
+            UpdateType::Sysupgrade(command) => match KI.perform_sysupgrade(command) {
+                Ok(_) => Ok(()),
+                Err(e) => Err(e),
+            },
             UpdateType::Opkg(commands) => {
-                //update the feed
-                let res = handle_release_feed_update(Some(commands.feed));
-                if let Err(e) = res {
-                    error!("Unable to update release feed for opkg update {:?}", e);
-                    return Err(e);
-                }
-                info!("Set new release feed for opkg");
-
-                //opkg commands
-                let mut res = Err(KernelInterfaceError::RuntimeError(
-                    "No commands given for opkg".to_string(),
-                ));
-                for cmd in commands.command_list {
-                    res = KI.perform_opkg(cmd);
-                    if res.is_err() {
-                        error!("Unable to perform opkg with error: {:?}", res);
-                        return res;
+                for cmd in commands {
+                    let res = KI.perform_opkg(cmd);
+                    if let Err(e) = res {
+                        error!("Unable to perform opkg with error: {:?}", e);
+                        return Err(e);
                     }
                 }
 
@@ -38,7 +27,7 @@ pub fn update_rita(instruction: UpdateType) -> Result<Output, KernelInterfaceErr
                 if let Err(e) = KI.run_command("/etc/init.d/rita", &args) {
                     error!("Unable to restart rita after opkg update: {}", e)
                 }
-                res
+                Ok(())
             }
         }
     } else {


### PR DESCRIPTION
Previously the UpgradeType::opkg struct had a number of limitations that
where not serious problems for our previous usage.

1) Each opkg update command had a type enum and then fields. The values
   of these fields may or may not make sense makes on the Enum resulting
   in redundant handling
2) It was only possible to set a single feed change at the start of the
   update instead of as many times as required
3) Each package update was installed individually. So while a single
   update command could contain many packages the actual command line
   would update one at a time
4) It was not possible to specify exactly which customfeed line you expected
   to modify.

This commit refactors the opkg update structs, creating a legacy
operator update command for backwards compatibility, removing a few
unused legacy instructions, adding support for the opkg remove command
and generally expanding the opkg update functionality to be prepared for
arbitrarily many package fees and significantly more advanced package
management.