### PR TITLE
Removing installation details on ops checkin

### DIFF
--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -222,6 +222,7 @@ async fn checkin() {
     let mut operator = rita_client.operator;
     let new_operator_fee = Uint256::from(new_settings.operator_fee);
     operator.operator_fee = new_operator_fee;
+    operator.installation_details = None;
     rita_client.operator = operator;
     merge_settings_safely(new_settings.merge_json.clone());
 


### PR DESCRIPTION
Installation details are stored in ops tools and are
unneeded on the router side. Checking in to ops will
now set installation details to None if successful