### PR TITLE
Changed NeighborStatus struct id field

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -700,7 +700,7 @@ pub enum EthOperationMode {
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct NeighborStatus {
     /// the id of the neighbor
-    pub id: Identity,
+    pub neighbor_id: Identity,
     /// their shaped wg interface speed in mbps
     pub shaper_speed: Option<usize>,
     /// If this user is currently being enforced upon

--- a/rita_common/src/tunnel_manager/neighbor_status.rs
+++ b/rita_common/src/tunnel_manager/neighbor_status.rs
@@ -46,7 +46,7 @@ pub fn update_neighbor_status() {
         external_list.insert(
             *id,
             NeighborStatus {
-                id: *id,
+                neighbor_id: *id,
                 shaper_speed: lowest_shaper_speed,
                 enforced,
             },


### PR DESCRIPTION
The NeighborStatus struct contained id as a field. This was
an issue since there's a duplicate id field inside deviceentryreturn
within operator_tools_server. This causes an issue with the search
on the frontend. It now is called neighbor_id.