### PR TITLE
Set the ipv6 address in router /etc/config/network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ name = "althea_kernel_interface"
 version = "0.1.0"
 dependencies = [
  "althea_types",
+ "ipnetwork 0.18.0",
  "itertools 0.10.3",
  "lazy_static",
  "log",

--- a/althea_kernel_interface/Cargo.toml
+++ b/althea_kernel_interface/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 serde_derive = "1.0"
 serde = "1.0"
 althea_types = { path = "../althea_types" }
+ipnetwork = "0.18"
 
 [dependencies.regex]
 version = "1.4"

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -201,23 +201,13 @@ impl dyn KernelInterface {
     }
 
     pub fn set_ipv6_route_to_tunnel(&self) -> Result<(), Error> {
-
         // Remove current default route
         if let Err(e) = self.run_command("ip", &["-6", "route", "del", "default"]) {
             warn!("Failed to delete default ip6 route {:?}", e);
         }
         // Set new default route
-        let output = self.run_command(
-            "ip",
-            &[
-                "-6",
-                "route",
-                "add",
-                "default",
-                "dev",
-                "wg_exit",
-            ],
-        )?;
+        let output =
+            self.run_command("ip", &["-6", "route", "add", "default", "dev", "wg_exit"])?;
         if !output.stderr.is_empty() {
             error!("IPV6 ERROR: Unable to set ip -6 default route");
             return Err(Error::RuntimeError(format!(

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -46,7 +46,7 @@ impl dyn KernelInterface {
                 "endpoint",
                 &format!("[{}]:{}", args.endpoint.ip(), args.endpoint.port()),
                 "allowed-ips",
-                "0.0.0.0/0",
+                "0.0.0.0/0, ::/0",
                 "persistent-keepalive",
                 "5",
             ],

--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -3,7 +3,7 @@ use althea_types::WgKey;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
-fn to_wg_local(ip: &IpAddr) -> IpAddr {
+pub fn to_wg_local(ip: &IpAddr) -> IpAddr {
     match *ip {
         IpAddr::V6(ip) => {
             let seg = ip.segments();

--- a/integration-tests/integration-test-script/world.py
+++ b/integration-tests/integration-test-script/world.py
@@ -448,8 +448,12 @@ class World:
                         node.id, intended_debts[node][owed], owed.id))
                     continue
                 if not fuzzy_match(debts[node.id][owed.id], intended_debts[node][owed]):
-                    print("{} has a predicted debt of {} for {} but actual debt is {} {:.2%} accurate".format(
+                    if debts[node.id][owed.id] != 0:
+                        print("{} has a predicted debt of {} for {} but actual debt is {} {:.2%} accurate".format(
                         node.id, intended_debts[node][owed], owed.id, debts[node.id][owed.id], intended_debts[node][owed]/debts[node.id][owed.id]))
+                    else:
+                        print("{} has a predicted debt of {} for {} but actual debt is {}".format(
+                        node.id, intended_debts[node][owed], owed.id, debts[node.id][owed.id]))
                 # exit(1)
 
     def get_best_route(self, all_routes, from_node, target_node):

--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -152,7 +152,7 @@ fn linux_setup_exit_tunnel(
 
     let args = ClientExitTunnelConfig {
         endpoint: SocketAddr::new(
-            get_selected_exit(exit.clone()).expect("There should be an exit ip here"),
+            get_selected_exit(exit).expect("There should be an exit ip here"),
             general_details.wg_exit_port,
         ),
         pubkey: current_exit.wg_public_key,

--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -152,7 +152,7 @@ fn linux_setup_exit_tunnel(
 
     let args = ClientExitTunnelConfig {
         endpoint: SocketAddr::new(
-            get_selected_exit(exit).expect("There should be an exit ip here"),
+            get_selected_exit(exit.clone()).expect("There should be an exit ip here"),
             general_details.wg_exit_port,
         ),
         pubkey: current_exit.wg_public_key,
@@ -169,6 +169,7 @@ fn linux_setup_exit_tunnel(
 
     KI.set_client_exit_tunnel_config(args, local_mesh_ip)?;
     KI.set_route_to_tunnel(&general_details.server_internal_ip)?;
+    KI.set_ipv6_route_to_tunnel()?;
 
     KI.create_client_nat_rules()?;
 

--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -141,6 +141,8 @@ fn linux_setup_exit_tunnel(
 ) -> Result<(), RitaClientError> {
     let mut rita_client = settings::get_rita_client();
     let mut network = rita_client.network;
+    let local_mesh_ip = network.mesh_ip;
+
     // TODO this should be refactored to return a value
     KI.update_settings_route(&mut network.last_default_route);
 
@@ -165,7 +167,7 @@ fn linux_setup_exit_tunnel(
     rita_client.network = network;
     settings::set_rita_client(rita_client);
 
-    KI.set_client_exit_tunnel_config(args)?;
+    KI.set_client_exit_tunnel_config(args, local_mesh_ip)?;
     KI.set_route_to_tunnel(&general_details.server_internal_ip)?;
 
     KI.create_client_nat_rules()?;
@@ -871,7 +873,7 @@ pub async fn exit_manager_tick() {
         }
     }
 
-    // This block runs after an exit manager tick (an exit is selected), 
+    // This block runs after an exit manager tick (an exit is selected),
     // and looks at the ipv6 subnet assigned to our router in the ExitState struct
     // which should be present after requesting general status from a registered exit.
     // This subnet is then added the lan network interface on the router to be used by slaac


### PR DESCRIPTION
When set under 'lan' in the network config, SLAAC take a subnet and assigns
a /64 address to hosts that connect. Rita exit sends a /60, we assign the router this
address in this commit and slaac does ip assignment