### PR TITLE
Fixes for usage tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,6 +2707,7 @@ dependencies = [
  "clarity",
  "compressed_log",
  "docopt",
+ "env_logger",
  "flate2",
  "futures 0.3.21",
  "hex-literal",

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -36,11 +36,14 @@ awc = {version = "3.0.0-beta.21", default-features = false, features=["openssl",
 actix-service = "2.0.2"
 web30 = "0.19"
 althea_types = { path = "../althea_types" }
-
 [dependencies.regex]
 version = "1.4"
 default-features = false
 features = ["std"]
+
+[dev-dependencies]
+env_logger = "0.9"
+
 [features]
 # disables cors for dash debugging
 dash_debug = []

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -682,7 +682,9 @@ pub fn save_debt_to_disk(save_frequency: Duration) {
     dk.save_if_needed(save_frequency);
 }
 
-/// On an interupt (SIGTERM), saving debtkeeper before exiting
+/// On an interupt (SIGTERM), saving debtkeeper before exiting, this will only
+/// happen if a reboot command is sent or an update is sent. The most common
+/// form of reboot (pulling the power) will not call this
 pub fn save_debt_on_shutdown() {
     let mut dk = DEBT_DATA.write().unwrap();
 

--- a/rita_common/src/rita_loop/write_to_disk.rs
+++ b/rita_common/src/rita_loop/write_to_disk.rs
@@ -1,12 +1,11 @@
 use crate::{debt_keeper::save_debt_to_disk, usage_tracker::save_usage_to_disk};
-use std::{
-    thread,
-    time::{Duration, Instant},
-};
-
 use settings::{
     check_if_exit, client::RitaClientSettings, exit::RitaExitSettingsStruct, get_rita_client,
     get_rita_exit, save_client_settings, save_exit_settings,
+};
+use std::{
+    thread,
+    time::{Duration, Instant},
 };
 /// How often we save the nodes debt data, currently 48 minutes
 const SAVE_FREQUENCY_EXIT: Duration = Duration::from_secs(172800);
@@ -84,14 +83,13 @@ pub fn save_to_disk_loop(mut old_settings: SettingsOnDisk, file_path: &str) {
             }
         }
 
-        // debt keeper
+        // debt keeper, only saved on graceful shutdown
         if !router_storage_small {
             save_debt_to_disk(save_frequency);
         }
 
-        let minimum_number_transactions: usize = 75;
-        //usage tracker is invoked via trafficwatch/watch() and the block runner
-        save_usage_to_disk(minimum_number_transactions);
+        // usage tracker monitors and saves bandwidth usage info and payment metadata
+        save_usage_to_disk();
     });
 }
 /// If the router storage is small/16mb
@@ -116,4 +114,8 @@ pub fn is_router_storage_small(router_model: &str) -> bool {
 fn test_is_router_storage_small() {
     let router = "linksys_e5600";
     assert!(is_router_storage_small(router));
+    let router = "x86_64";
+    assert!(!is_router_storage_small(router));
+    let router = "test";
+    assert!(!is_router_storage_small(router));
 }


### PR DESCRIPTION
This patch includes a large number of fixes for mistakes in the usage
tracker module. A series of implementation errors and oversights have
built up in this module during it's recent changes.

Large Errors:

1) Premature removal of json conversion code

Due to an oversight when this file was modified to reduce the frequency
of saving to the disk json conversion was removed as part of the beta
17->18 transition. A clear comment had been placed at the top of the
function when this transition was put in place outlining that it was not
to be removed until beta 20, after the 18->19 transition had occured.

This was not noticed by the author or reviewer. Resutling in most
production users usage tracker history being discarded during the 18->19 transition.

2) convert_legacy_usage_tracker test did not actually test conversion

Because this test used an empty dummy struct if the json file was not
actually present or failed to deserialize it would succeed anyways as it
was comparing to the default value subsituted in this case. This test
would locate any panics or control flow issues but was incomplete from
the time it was written.

3) Accidental editing of the usage tracker struct

The function check_usage_hour should never have taken a mutable
reference. The intent of the function is clearly read only, to check how
much data has been used. The algorithm used to do this involves
modifying the struct becuase it was passed mutably it was dropping
actual user data and resulting in the user losing some of their latest
usage data every time it was run.

This usage of a mutable reference probably came from a compiler
suggestion and was overlooked by the author and reviewer

Changes:

This patch corrects these oversights and introduces a new test suite for
usage tracker which generates enormous test structs containing up to
several hundred megabytes of fake usage data. This should allow for more
comprehensive testing in the future and prevent data-corruption bugs
from slipping through so easily.

Changes unrelated to these errors include setting the trigger level for
regular tx saving to only 5 transactions for routers with large fash
rather than 75.

Transaction history saving on shutdown has been simplified, resulting in
a save on shutdown if the write conditions have been met. Rather than
creating an odd exception where routers with small storage would not
save on graceful restart despite being prepared to save a few minutes
later under normal circumstances.