### PR TITLE
Unique Exit Identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "email_address"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8684b7c9cb4857dfa1e5b9629ef584ba618c9b93bae60f58cb23f4f271d0468e"
+checksum = "b1b32a7a2580c4473f10f66b512c34bdd7d33c5e3473227ca833abdb5afe4809"
 
 [[package]]
 name = "encoding_rs"
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libsodium-sys"
@@ -2411,9 +2411,9 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2661,12 +2661,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
 dependencies = [
  "itoa",
- "js-sys",
  "libc",
  "num_threads",
  "time-macros",

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -3,6 +3,7 @@ use crate::{open_tunnel::to_wg_local, KernelInterfaceError as Error};
 use althea_types::WgKey;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+#[derive(Debug)]
 pub struct ClientExitTunnelConfig {
     /// The mesh ip of the exit server and it's port
     pub endpoint: SocketAddr,

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -98,7 +98,7 @@ impl dyn KernelInterface {
         interface: &str,
     ) {
         // Setup ipv4 route
-        // 1.) Select all ipv4 routes with 'client_internal_ip'. This gives us all routes with wg_exit and wg_exit_new for the ip
+        // 1.) Select all ipv4 routes with 'client_internal_ip'. This gives us all routes with wg_exit and wg_exit_v2 for the ip
         //     THere should be only one route
         // 2.) Does the route contain 'interface'? Yes? we continue
         // 3.) No? That means either no route exists or there is a route with the other interface name
@@ -119,7 +119,7 @@ impl dyn KernelInterface {
         }
 
         // Setup ipv6 routes
-        // 1.) Find all v6 routes with ip. There should be at most one, either on wg_exit or wg_exit_new
+        // 1.) Find all v6 routes with ip. There should be at most one, either on wg_exit or wg_exit_v2
         // 2.) Check if that route contains 'interface' Yes? route is already setup, we continue
         // 3.) No? It means no route exists or route exists on wrong interface.
         // 4.) We delete route and add the new route on correct interface

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -100,8 +100,15 @@ impl dyn KernelInterface {
             return;
         }
 
-        // Delete an older routes that exists if the router has recently switched
-        //let old_router; // TODO
+        // Get all routes on our interface
+        let output = self.run_command("ip", &vec!["-6", "route", "show", "dev", interface]).expect("Fix command");
+        let existing_routes = String::from_utf8(output.stdout).unwrap();
+
+        // Turn into a vector of Vec<IpRoute>
+        //let routes = parse_iproute_string(existing_routes);
+        
+
+
 
         let ipv6_list: Vec<&str> = client_ipv6_list.split(',').collect();
 

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -195,6 +195,8 @@ impl dyn KernelInterface {
         client_internal_ip: String,
         interface: &str,
     ) {
+        let mut interface_cloned = interface.to_string();
+        interface_cloned.push(' ');
         // Setup ipv4 route
         // 1.) Select all ipv4 routes with 'client_internal_ip'. This gives us all routes with wg_exit and wg_exit_v2 for the ip
         //     THere should be only one route
@@ -205,7 +207,7 @@ impl dyn KernelInterface {
             .run_command("ip", &["route", "show", &client_internal_ip])
             .expect("Fix command");
         let route = String::from_utf8(output.stdout).unwrap();
-        if !route.contains(&interface) {
+        if !route.contains(&interface_cloned) {
             self.run_command("ip", &["route", "del", &client_internal_ip])
                 .expect("Fix command");
 
@@ -237,7 +239,7 @@ impl dyn KernelInterface {
                     .run_command("ip", &["-6", "route", "show", &ip_net.to_string()])
                     .expect("Fix command");
                 let existing_routes = String::from_utf8(output.stdout).unwrap();
-                if !existing_routes.contains(interface) {
+                if !existing_routes.contains(&interface_cloned) {
                     self.run_command("ip", &["-6", "route", "del", &ip_net.to_string()])
                         .expect("Fix command");
 

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -100,6 +100,9 @@ impl dyn KernelInterface {
             return;
         }
 
+        // Delete an older routes that exists if the router has recently switched
+        //let old_router; // TODO
+
         let ipv6_list: Vec<&str> = client_ipv6_list.split(',').collect();
 
         for ip in ipv6_list {

--- a/althea_kernel_interface/src/iptables.rs
+++ b/althea_kernel_interface/src/iptables.rs
@@ -40,4 +40,15 @@ impl dyn KernelInterface {
 
         Ok(())
     }
+
+    pub fn check_iptable_rule(
+        &self,
+        command: &str,
+        rule: &[&str],
+    ) -> Result<bool, KernelInterfaceError> {
+        assert!(rule.contains(&"-C"));
+
+        let check = self.run_command(command, rule)?;
+        Ok(check.status.success())
+    }
 }

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -75,8 +75,8 @@ impl dyn KernelInterface {
     }
 
     /// Returns the number of clients that are active on the wg_exit tunnel
-    pub fn get_wg_exit_clients_online(&self) -> Result<u32, Error> {
-        let output = self.run_command("wg", &["show", "wg_exit", "latest-handshakes"])?;
+    pub fn get_wg_exit_clients_online(&self, interface: &str) -> Result<u32, Error> {
+        let output = self.run_command("wg", &["show", interface, "latest-handshakes"])?;
         let mut num: u32 = 0;
         let out = String::from_utf8(output.stdout)?;
         for line in out.lines() {
@@ -194,7 +194,7 @@ fn test_get_wg_exit_clients_online() {
         }
     }));
 
-    assert_eq!(KI.get_wg_exit_clients_online().unwrap(), 1);
+    assert_eq!(KI.get_wg_exit_clients_online("wg_exit").unwrap(), 1);
 }
 
 #[test]

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -60,6 +60,7 @@ impl dyn KernelInterface {
     /// calls iproute2 to set up a new interface with a given name.
     pub fn setup_wg_if_named(&self, name: &str) -> Result<(), KernelInterfaceError> {
         let output = self.run_command("ip", &["link", "add", name, "type", "wireguard"])?;
+        info!("Added the wg_exit interface");
         let stderr = String::from_utf8(output.stderr)?;
         if !stderr.is_empty() {
             if stderr.contains("exists") {
@@ -71,6 +72,7 @@ impl dyn KernelInterface {
                 )));
             }
         }
+        info!("wg_exit should be successfully setup");
         Ok(())
     }
 

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -129,6 +129,14 @@ impl dyn KernelInterface {
 }
 
 #[test]
+fn test_durations() {
+    let d = UNIX_EPOCH + Duration::from_secs(5);
+    let d2 = UNIX_EPOCH + Duration::from_secs(10);
+
+    println!("d: {:?}, d2: {:?}", d, d2);
+}
+
+#[test]
 fn test_setup_wg_if_linux() {
     use crate::KI;
 

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -60,7 +60,6 @@ impl dyn KernelInterface {
     /// calls iproute2 to set up a new interface with a given name.
     pub fn setup_wg_if_named(&self, name: &str) -> Result<(), KernelInterfaceError> {
         let output = self.run_command("ip", &["link", "add", name, "type", "wireguard"])?;
-        info!("Added the wg_exit interface");
         let stderr = String::from_utf8(output.stderr)?;
         if !stderr.is_empty() {
             if stderr.contains("exists") {
@@ -72,7 +71,6 @@ impl dyn KernelInterface {
                 )));
             }
         }
-        info!("wg_exit should be successfully setup");
         Ok(())
     }
 

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -255,9 +255,17 @@ pub struct EncryptedExitState {
 
 /// Wrapper for secure box containing a list of ips
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
-pub struct EncryptedIpList {
+pub struct EncryptedExitList {
     pub nonce: [u8; 24],
-    pub ip_list: Vec<u8>,
+    pub exit_list: Vec<u8>,
+}
+
+/// Struct returned when hitting exit_list endpoint
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct ExitList {
+    pub exit_list: Vec<Identity>,
+    // All exits in a cluster listen on same port
+    pub wg_exit_listen_port: u16,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -253,6 +253,13 @@ pub struct EncryptedExitState {
     pub encrypted_exit_state: Vec<u8>,
 }
 
+/// Wrapper for secure box containing a list of ips
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+pub struct EncryptedIpList {
+    pub nonce: [u8; 24],
+    pub ip_list: Vec<u8>,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ExitVerifMode {
     Phone,

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -116,7 +116,7 @@ This file documents the dashboard API found in Rita client.
 
 - URL: `<rita ip>:<rita_dashboard_port>/exits'
 - Comment: Merges a supplied exit list with the existing list; existing entries
-  are overwritten. Once client side subnet is removed, replace 'subnet' with 'root_ip'
+  are overwritten.
 - Method: `POST`
 - URL Params: `None`
 - Data Params: A JSON object containing the exits we want to add, e.g.:
@@ -134,7 +134,7 @@ This file documents the dashboard API found in Rita client.
 		},
     "wg_public_key": "KaTbsJ0Hur4D7Tcb+nc8ofs7n8tKL+wWG3H38KFCwlE=",
 		"eth_address": "0x0101010101010101010101010101010101010101",
-    "subnet": "fd00::5/120",
+    "root_ip": "fd00::5",
 		"message": "Got info successfully",
 		"registration_port": 4875,
 	  "state": "GotInfo"
@@ -152,7 +152,7 @@ This file documents the dashboard API found in Rita client.
 		},
     "wg_public_key": "KaTbsJ0Hur4D7Tcb+nc8ofs7n8tKL+wWG3H38KFCwlE=",
 		"eth_address": "0x0101010101010101010101010101010101010101",
-    "subnet": "fd00::5/120",
+    "root_ip": "fd00::5",
 		"message": "Got info successfully",
 		"registration_port": 4875,
 		"state": "GotInfo"

--- a/integration-tests/integration-test-script/rita.py
+++ b/integration-tests/integration-test-script/rita.py
@@ -88,18 +88,14 @@ TEST_PASSES = True
 EXIT_SETTINGS = {
     "new_exits": {
         "exit_a": {
-            "subnet": "fd00::5/128",
+            "root_ip": "fd00::5",
             "id": {
                 "mesh_ip": "fd00::5",
                 "eth_address": "0xbe398dc24de37c73cec974d688018e58f94d6e0a",
-                "wg_public_key": "fd00::5",
-            },
-            "subnet_len": 128,
-            "selected_exit": {
-                "selected_id": "fd00::5"
+                "wg_public_key": "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU=",
             },
             "eth_address": "0xbe398dc24de37c73cec974d688018e58f94d6e0a",
-            "wg_public_key": "fd00::5",
+            "wg_public_key": "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU=",
             "registration_port": 4875,
             "state": "New",
         }

--- a/integration-tests/integration-test-script/world.py
+++ b/integration-tests/integration-test-script/world.py
@@ -209,6 +209,7 @@ class World:
                                  verbose=verbose, global_fail=global_fail):
                 ret = False
         if global_fail and not ret:
+            time.sleep(400)
             exit(1)
         return ret
 

--- a/integration-tests/integration-test-script/world.py
+++ b/integration-tests/integration-test-script/world.py
@@ -209,7 +209,6 @@ class World:
                                  verbose=verbose, global_fail=global_fail):
                 ret = False
         if global_fail and not ret:
-            time.sleep(400)
             exit(1)
         return ret
 

--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -126,7 +126,7 @@ pub async fn add_exits(new_exits: Json<HashMap<String, ExitServer>>) -> HttpResp
 
     // initialze all new exits for Exit manager to use
     for exit in new_copy {
-        let new_exit_ip = exit.1.subnet.ip();
+        let new_exit_ip = exit.1.root_ip;
         let new_selected_exit = SelectedExit {
             selected_id: Some(new_exit_ip),
             ..Default::default()

--- a/rita_client/src/exit_manager/exit_switcher.rs
+++ b/rita_client/src/exit_manager/exit_switcher.rs
@@ -456,9 +456,13 @@ fn get_exit_metrics(
             "Route hashmap: {:?}\n, ip mesh: {:?}\n",
             route_hashmap, ip.mesh_ip
         );
-        let route = route_hashmap
-            .get(&ip.mesh_ip)
-            .expect("There should be an ip address for every route");
+        let route = match route_hashmap.get(&ip.mesh_ip) {
+            Some(a) => a,
+            None => {
+                error!("EXIT_SWITCHER: Invalid ip: {:?}", ip.mesh_ip);
+                continue;
+            }
+        };
         let ip = route.prefix.ip();
 
         if !blacklisted.contains(&ip) {

--- a/rita_client/src/exit_manager/exit_switcher.rs
+++ b/rita_client/src/exit_manager/exit_switcher.rs
@@ -452,7 +452,10 @@ fn get_exit_metrics(
 
     for ip in exit_list.exit_list.clone() {
         // All babel routes are advertised as /128, so we check if each 'single' ip is part of exit subnet
-        info!("Route hashmap: {:?}\n, ip mesh: {:?}\n", route_hashmap, ip.mesh_ip);
+        info!(
+            "Route hashmap: {:?}\n, ip mesh: {:?}\n",
+            route_hashmap, ip.mesh_ip
+        );
         let route = route_hashmap
             .get(&ip.mesh_ip)
             .expect("There should be an ip address for every route");

--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -29,10 +29,10 @@ use althea_kernel_interface::{
     exit_client_tunnel::ClientExitTunnelConfig, DefaultRoute, KernelInterfaceError,
 };
 use althea_types::ExitClientDetails;
-use althea_types::ExitDetails;
 use althea_types::Identity;
 use althea_types::WgKey;
 use althea_types::{EncryptedExitClientIdentity, EncryptedExitState};
+use althea_types::{EncryptedExitList, ExitDetails, ExitList};
 use althea_types::{ExitClientIdentity, ExitRegistrationDetails, ExitState, ExitVerifMode};
 use exit_switcher::{get_babel_routes, set_best_exit};
 
@@ -81,6 +81,21 @@ pub struct ExitManager {
     /// It also holds information about metrics and degradation values. Look at doc comment on 'set_best_exit' for more
     /// information on what these mean
     pub selected_exit_list: HashMap<String, SelectedExit>,
+    /// Every tick we query an exit endpoint to get a list of exits in that cluster. We use this list for exit switching
+    pub exit_list: ExitList,
+}
+
+/// This functions sets the exit list ONLY IF the list arguments provived is not empty. This is need for the following edge case:
+/// When an exit goes down, the endpoint wont repsond, so we have no exits to switch to. By setting only when we have a length > 1
+/// we assure that we switch when an exit goes down
+pub fn set_exit_list(list: ExitList) {
+    if !list.exit_list.is_empty() {
+        EXIT_MANAGER.write().unwrap().exit_list = list;
+    }
+}
+
+pub fn get_exit_list() -> ExitList {
+    EXIT_MANAGER.read().unwrap().exit_list.clone()
 }
 
 pub fn get_selected_exit(exit: String) -> Option<IpAddr> {
@@ -129,9 +144,9 @@ pub fn get_em_nat() -> bool {
 
 fn linux_setup_exit_tunnel(
     exit: String,
-    current_exit: &ExitServer,
     general_details: &ExitDetails,
     our_details: &ExitClientDetails,
+    exit_list: &ExitList,
 ) -> Result<(), RitaClientError> {
     let mut rita_client = settings::get_rita_client();
     let mut network = rita_client.network;
@@ -144,12 +159,10 @@ fn linux_setup_exit_tunnel(
         return Err(RitaClientError::MiscStringError(v));
     }
 
+    let selected_ip = get_selected_exit(exit).expect("There should be an exit ip here");
     let args = ClientExitTunnelConfig {
-        endpoint: SocketAddr::new(
-            get_selected_exit(exit).expect("There should be an exit ip here"),
-            general_details.wg_exit_port,
-        ),
-        pubkey: current_exit.wg_public_key,
+        endpoint: SocketAddr::new(selected_ip, exit_list.wg_exit_listen_port),
+        pubkey: get_exit_pubkey(selected_ip, exit_list),
         private_key_path: network.wg_private_key_path.clone(),
         listen_port: rita_client.exit_client.wg_listen_port,
         local_ip: our_details.client_internal_ip,
@@ -168,6 +181,18 @@ fn linux_setup_exit_tunnel(
     KI.create_client_nat_rules()?;
 
     Ok(())
+}
+
+/// From a exit list, find the corresponding wg public key of our current connected exit to
+/// set up wg tunnels
+fn get_exit_pubkey(ip: IpAddr, exit_list: &ExitList) -> WgKey {
+    for id in exit_list.exit_list.clone() {
+        if id.mesh_ip == ip {
+            return id.wg_public_key;
+        }
+    }
+
+    panic!("Unable to find a valid wg key for current exit, please check that all exit Identities are properly setup on the exit");
 }
 
 fn restore_nat() {
@@ -570,6 +595,115 @@ async fn exit_status_request(exit: String) -> Result<(), RitaClientError> {
     Ok(())
 }
 
+async fn get_cluster_ip_list(exit: String) -> Result<ExitList, RitaClientError> {
+    let current_exit_cluster = match settings::get_rita_client().exit_client.exits.get(&exit) {
+        Some(current_exit) => current_exit.clone(),
+        None => {
+            return Err(RitaClientError::NoExitError(exit));
+        }
+    };
+
+    let exit_pubkey = current_exit_cluster.wg_public_key;
+    let reg_details = match settings::get_rita_client().exit_client.contact_info {
+        Some(val) => val.into(),
+        None => {
+            return Err(RitaClientError::MiscStringError(
+                "No valid details".to_string(),
+            ))
+        }
+    };
+    let ident = ExitClientIdentity {
+        global: match settings::get_rita_client().get_identity() {
+            Some(id) => id,
+            None => {
+                return Err(RitaClientError::MiscStringError(
+                    "Identity has no mesh IP ready yet".to_string(),
+                ));
+            }
+        },
+        wg_port: settings::get_rita_client().exit_client.wg_listen_port,
+        reg_details,
+    };
+
+    let current_exit_ip = get_selected_exit(exit.clone());
+    let exit_server = current_exit_ip.expect("There should be an exit ip here");
+
+    let endpoint = format!(
+        "http://[{}]:{}/exit_list",
+        exit_server, current_exit_cluster.registration_port
+    );
+    let ident = encrypt_exit_client_id(&exit_pubkey.into(), ident);
+
+    let client = awc::Client::default();
+    let response = client
+        .post(&endpoint)
+        .timeout(CLIENT_LOOP_TIMEOUT)
+        .send_json(&ident)
+        .await;
+    let mut response = match response {
+        Ok(a) => {
+            reset_blacklist_warnings(exit_server);
+            a
+        }
+        Err(awc::error::SendRequestError::Timeout) => {
+            // Did not get a response, is it a rogue exit or some netork error?
+            blacklist_strike_ip(exit_server, WarningType::SoftWarning);
+            return Err(RitaClientError::SendRequestError(
+                awc::error::SendRequestError::Timeout.to_string(),
+            ));
+        }
+        Err(e) => return Err(RitaClientError::SendRequestError(e.to_string())),
+    };
+
+    let value = response.json().await?;
+
+    match decrypt_exit_list(value, exit_pubkey.into()) {
+        Err(e) => {
+            blacklist_strike_ip(exit_server, WarningType::HardWarning);
+            Err(e)
+        }
+        Ok(a) => {
+            reset_blacklist_warnings(exit_server);
+            Ok(a)
+        }
+    }
+}
+
+fn decrypt_exit_list(
+    exit_list: EncryptedExitList,
+    exit_pubkey: PublicKey,
+) -> Result<ExitList, RitaClientError> {
+    let rita_client = settings::get_rita_client();
+    let network_settings = rita_client.network;
+    let our_secretkey = network_settings
+        .wg_private_key
+        .expect("No private key?")
+        .into();
+    let ciphertext = exit_list.exit_list;
+    let nonce = Nonce(exit_list.nonce);
+    let ret: ExitList = match box_::open(&ciphertext, &nonce, &exit_pubkey, &our_secretkey) {
+        Ok(decrypted_bytes) => match String::from_utf8(decrypted_bytes) {
+            Ok(json_string) => match serde_json::from_str(&json_string) {
+                Ok(ip_list) => ip_list,
+                Err(e) => {
+                    return Err(e.into());
+                }
+            },
+            Err(e) => {
+                error!("Could not deserialize exit state with {:?}", e);
+                return Err(e.into());
+            }
+        },
+        Err(_) => {
+            error!("Could not decrypt exit state");
+            return Err(RitaClientError::MiscStringError(
+                "Could not decrypt exit state".to_string(),
+            ));
+        }
+    };
+    Ok(ret)
+}
+
 fn correct_default_route(input: Option<DefaultRoute>) -> bool {
     match input {
         Some(v) => v.is_althea_default_route(),
@@ -606,6 +740,7 @@ pub async fn exit_manager_tick() {
         Some(a) => a,
         None => "".to_string(),
     };
+
     let last_exit = get_selected_exit(current_exit.clone());
     let mut exits = rita_client.exit_client.exits;
 
@@ -625,7 +760,6 @@ pub async fn exit_manager_tick() {
 
             // Logic to determnine what the best exit is and if we should switch
             let babel_port = settings::get_rita_client().network.babel_port;
-            let exit_subnet = exit.subnet;
 
             let routes = match get_babel_routes(babel_port) {
                 Ok(a) => a,
@@ -635,8 +769,31 @@ pub async fn exit_manager_tick() {
                 }
             };
 
+            // Get cluster exit list. This is saved locally and updated every tick depending on what exit we connect to.
+            // When it is empty, it means an exit we connected to went down, and we use the list from memory to connect to a new instance
+            let exit_list = match get_cluster_ip_list(current_exit.clone()).await {
+                Ok(a) => a,
+                Err(e) => {
+                    error!("Exit_Switcher: Unable to get exit list: {:?}", e);
+                    ExitList {
+                        exit_list: Vec::new(),
+                        wg_exit_listen_port: 0,
+                    }
+                }
+            };
+            info!(
+                "Received a cluster exit list from the exit: {:?}",
+                exit_list
+            );
+            if exit_list.exit_list.is_empty() {
+                error!("Exit_Switcher: Exit_list Error, it should not be empty");
+            }
+            set_exit_list(exit_list);
+
+            // Calling set best exit function, this looks though a list of exit in a cluster, does some math, and determines what exit we should connect to
+            let exit_list = get_exit_list();
             info!("Exit_Switcher: Calling set best exit");
-            let selected_exit = match set_best_exit(current_exit.clone(), exit_subnet, routes) {
+            let selected_exit = match set_best_exit(current_exit.clone(), routes, &exit_list) {
                 Ok(a) => Some(a),
                 Err(e) => {
                     warn!("Found no exit yet : {}", e);
@@ -662,9 +819,9 @@ pub async fn exit_manager_tick() {
                     trace!("Exit change, setting up exit tunnel");
                     linux_setup_exit_tunnel(
                         current_exit,
-                        exit,
                         &general_details.clone(),
                         exit.info.our_details().unwrap(),
+                        &exit_list,
                     )
                     .expect("failure setting up exit tunnel");
                     set_em_nat(true);
@@ -673,9 +830,9 @@ pub async fn exit_manager_tick() {
                     trace!("DHCP overwrite setup exit tunnel again");
                     linux_setup_exit_tunnel(
                         current_exit,
-                        exit,
                         &general_details.clone(),
                         exit.info.our_details().unwrap(),
+                        &exit_list,
                     )
                     .expect("failure setting up exit tunnel");
                     set_em_nat(true);

--- a/rita_client/src/exit_manager/time_sync.rs
+++ b/rita_client/src/exit_manager/time_sync.rs
@@ -3,6 +3,8 @@ use althea_types::ExitSystemTime;
 use settings::client::ExitServer;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::exit_manager::get_selected_exit;
+
 /// The max time difference between the local router's time and the exit's before resetting the local time to the exit's
 const MAX_DIFF_LOCAL_EXIT_TIME: Duration = Duration::from_secs(60);
 
@@ -11,9 +13,9 @@ const MAX_DIFF_LOCAL_EXIT_TIME: Duration = Duration::from_secs(60);
 const MAX_EXIT_TUNNEL_HANDSHAKE: Duration = Duration::from_secs(60 * 3);
 
 /// Retrieve a unix timestamp from the exit's mesh IPv6
-pub async fn get_exit_time(exit: ExitServer) -> Option<SystemTime> {
+pub async fn get_exit_time(exit: ExitServer, exit_name: String) -> Option<SystemTime> {
     info!("Getting the exit time");
-    let exit_ip = exit.subnet.ip();
+    let exit_ip = get_selected_exit(exit_name).expect("There should be an exit ip here");
     let exit_port = exit.registration_port;
     let url = format!("http://[{}]:{}/time", exit_ip, exit_port);
 
@@ -55,7 +57,7 @@ pub fn get_latest_exit_handshake() -> Option<SystemTime> {
 /// Check for a handshake time for wg_exit. We might not get one if there's no tunnel
 /// if there's no handshake or the handshake is more than 10 mins old, then try to get the exit time
 /// if we do get the exit time and it's more than 60 secs different than local time, then set the local time to it
-pub async fn maybe_set_local_to_exit_time(exit: ExitServer) {
+pub async fn maybe_set_local_to_exit_time(exit: ExitServer, cluster_name: String) {
     let now = SystemTime::now();
 
     if let Some(last_handshake) = get_latest_exit_handshake() {
@@ -86,7 +88,7 @@ pub async fn maybe_set_local_to_exit_time(exit: ExitServer) {
     }
 
     // if we're here, then it means we didn't get a reasonable handshake
-    if let Some(exit_time) = get_exit_time(exit).await {
+    if let Some(exit_time) = get_exit_time(exit, cluster_name).await {
         // if exit time is more than 60 secs later than our time, set ours to its
         if let Ok(diff) = exit_time.duration_since(now) {
             if diff > MAX_DIFF_LOCAL_EXIT_TIME {

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -386,7 +386,12 @@ pub fn setup_clients(
                     continue;
                 }
             };
-        KI.setup_client_routes(c.internet_ipv6.clone(), c.mesh_ip.clone(), &interface)
+        KI.setup_client_routes(
+            c.internet_ipv6.clone(),
+            c.mesh_ip.clone(),
+            c.internal_ip.clone(),
+            &interface,
+        )
     }
 
     trace!("converted clients {:?}", wg_clients);
@@ -448,6 +453,7 @@ pub fn get_client_interface(
     new_wg_exit_clients: HashMap<WgKey, SystemTime>,
     wg_exit_clients: HashMap<WgKey, SystemTime>,
 ) -> Result<String, RitaExitError> {
+    info!("New list is {:?} \n Old list is {:?}", new_wg_exit_clients, wg_exit_clients);
     match (
         new_wg_exit_clients.get(&c.wg_pubkey.parse()?),
         wg_exit_clients.get(&c.wg_pubkey.parse()?),

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -356,7 +356,7 @@ pub fn setup_clients(
 
     // Setup or verify that an ipv6 route exists for each client
     let new_wg_exit_clients: HashMap<WgKey, SystemTime> = KI
-        .get_last_handshake_time("wg_exit_new")
+        .get_last_handshake_time("wg_exit_v2")
         .expect("There should be a new wg_exit interface")
         .into_iter()
         .collect();
@@ -381,7 +381,7 @@ pub fn setup_clients(
             match get_client_interface(c, new_wg_exit_clients.clone(), wg_exit_clients.clone()) {
                 Ok(a) => a,
                 Err(_) => {
-                    // There is no handshake on either wg_exit or wg_exit_new, which can happen during a restart
+                    // There is no handshake on either wg_exit or wg_exit_v2, which can happen during a restart
                     // in this case the client will not have an ipv6 route until they initiate a handshake again
                     continue;
                 }
@@ -403,7 +403,7 @@ pub fn setup_clients(
         return Ok(wg_clients);
     }
 
-    info!("Setting up configs for wg_exit and wg_exit_new");
+    info!("Setting up configs for wg_exit and wg_exit_v2");
     // setup all the tunnels
     let exit_status = KI.set_exit_wg_config(
         &wg_clients,
@@ -415,9 +415,9 @@ pub fn setup_clients(
     // Setup new tunnels
     let exit_status_new = KI.set_exit_wg_config(
         &wg_clients,
-        settings::get_rita_exit().exit_network.wg_new_tunnel_port,
+        settings::get_rita_exit().exit_network.wg_v2_tunnel_port,
         &settings::get_rita_exit().network.wg_private_key_path,
-        "wg_exit_new",
+        "wg_exit_v2",
     );
 
     match exit_status {
@@ -461,11 +461,11 @@ pub fn get_client_interface(
         new_wg_exit_clients.get(&c.wg_pubkey.parse()?),
         wg_exit_clients.get(&c.wg_pubkey.parse()?),
     ) {
-        (Some(_), None) => Ok("wg_exit_new".into()),
+        (Some(_), None) => Ok("wg_exit_v2".into()),
         (None, Some(_)) => Ok("wg_exit".into()),
         (Some(new), Some(old)) => {
             if new > old {
-                Ok("wg_exit_new".into())
+                Ok("wg_exit_v2".into())
             } else {
                 Ok("wg_exit".into())
             }
@@ -523,7 +523,7 @@ pub fn enforce_exit_clients(
     }
 
     let new_wg_exit_clients: HashMap<WgKey, SystemTime> = KI
-        .get_last_handshake_time("wg_exit_new")
+        .get_last_handshake_time("wg_exit_v2")
         .expect("There should be a new wg_exit interface")
         .into_iter()
         .collect();

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -398,6 +398,7 @@ pub fn setup_clients(
         return Ok(wg_clients);
     }
 
+    info!("Setting up configs for wg_exit and wg_exit_new");
     // setup all the tunnels
     let exit_status = KI.set_exit_wg_config(
         &wg_clients,

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -391,7 +391,21 @@ pub fn setup_clients(
             c.mesh_ip.clone(),
             c.internal_ip.clone(),
             &interface,
-        )
+        );
+
+        let ex_nic = settings::get_rita_exit()
+            .network
+            .external_nic
+            .expect("Expected an external nic here");
+
+        let res = KI.setup_client_rules(
+            c.internet_ipv6.clone(),
+            c.mesh_ip.clone(),
+            &interface,
+            ex_nic.clone(),
+        );
+
+        info!("IPV6: Setup client ip6tables rules with: {:?}", res);
     }
 
     trace!("converted clients {:?}", wg_clients);

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -453,7 +453,10 @@ pub fn get_client_interface(
     new_wg_exit_clients: HashMap<WgKey, SystemTime>,
     wg_exit_clients: HashMap<WgKey, SystemTime>,
 ) -> Result<String, RitaExitError> {
-    info!("New list is {:?} \n Old list is {:?}", new_wg_exit_clients, wg_exit_clients);
+    info!(
+        "New list is {:?} \n Old list is {:?}",
+        new_wg_exit_clients, wg_exit_clients
+    );
     match (
         new_wg_exit_clients.get(&c.wg_pubkey.parse()?),
         wg_exit_clients.get(&c.wg_pubkey.parse()?),
@@ -469,12 +472,10 @@ pub fn get_client_interface(
         }
         _ => {
             error!(
-                "WG EXIT SETUP: Client {}, does not have handshake with any wg exit interface",
+                "WG EXIT SETUP: Client {}, does not have handshake with any wg exit interface. Setting up routes on wg_exit",
                 c.wg_pubkey
             );
-            Err(RitaExitError::MiscStringError(
-                "Unable to find client interface".to_string(),
-            ))
+            Ok("wg_exit".into())
         }
     }
 }

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -248,7 +248,7 @@ pub async fn get_exit_list(request: Json<EncryptedExitClientIdentity>) -> HttpRe
 
     let ret: ExitList = ExitList {
         exit_list: settings::get_rita_exit().exit_network.cluster_exits,
-        wg_exit_listen_port: settings::get_rita_exit().exit_network.wg_new_tunnel_port,
+        wg_exit_listen_port: settings::get_rita_exit().exit_network.wg_v2_tunnel_port,
     };
 
     let plaintext = serde_json::to_string(&ret)

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -13,11 +13,11 @@ use actix::SystemService;
 #[cfg(feature = "development")]
 use actix_web::AsyncResponder;
 use actix_web_async::{http::StatusCode, web::Json, HttpRequest, HttpResponse, Result};
-use althea_types::WgKey;
 use althea_types::{
     EncryptedExitClientIdentity, EncryptedExitState, ExitClientIdentity, ExitState, ExitSystemTime,
 };
-use althea_types::{EncryptedIpList, Identity};
+use althea_types::{EncryptedExitList, Identity};
+use althea_types::{ExitList, WgKey};
 use num256::Int256;
 use rita_common::blockchain_oracle::potential_payment_issues_detected;
 use rita_common::debt_keeper::get_debts_list;
@@ -246,16 +246,19 @@ pub async fn get_exit_list(request: Json<EncryptedExitClientIdentity>) -> HttpRe
 
     let their_nacl_pubkey = request.pubkey.into();
 
-    let ret = settings::get_rita_exit().exit_network.cluster_ips;
+    let ret: ExitList = ExitList {
+        exit_list: settings::get_rita_exit().exit_network.cluster_exits,
+        wg_exit_listen_port: settings::get_rita_exit().exit_network.wg_new_tunnel_port,
+    };
 
     let plaintext = serde_json::to_string(&ret)
         .expect("Failed to serialize Vec of ips!")
         .into_bytes();
     let nonce = box_::gen_nonce();
     let ciphertext = box_::seal(&plaintext, &nonce, &their_nacl_pubkey, &our_secretkey);
-    HttpResponse::Ok().json(Json(EncryptedIpList {
+    HttpResponse::Ok().json(Json(EncryptedExitList {
         nonce: nonce.0,
-        ip_list: ciphertext,
+        exit_list: ciphertext,
     }))
 }
 

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -225,7 +225,7 @@ fn setup_exit_wg_tunnel() {
         warn!("exit setup returned {}", e)
     }
     // Setup new wg_exit
-    if let Err(e) = KI.setup_wg_if_named("wg_exit_new") {
+    if let Err(e) = KI.setup_wg_if_named("wg_exit_v2") {
         warn!("new exit setup returned {}", e)
     }
 
@@ -248,8 +248,8 @@ fn setup_exit_wg_tunnel() {
         .expect("Failed to setup wg_exit!");
 
     // Setup new wg_exit
-    KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic, "wg_exit_new")
-        .expect("Failed to setup wg_exit_new!");
+    KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic, "wg_exit_v2")
+        .expect("Failed to setup wg_exit_v2!");
 
     KI.setup_nat(
         &settings::get_rita_exit().network.external_nic.unwrap(),
@@ -258,7 +258,7 @@ fn setup_exit_wg_tunnel() {
     .unwrap();
     KI.setup_nat(
         &settings::get_rita_exit().network.external_nic.unwrap(),
-        "wg_exit_new",
+        "wg_exit_v2",
     )
     .unwrap();
 }

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -275,7 +275,7 @@ pub fn start_rita_exit_endpoints(workers: usize) {
                     .route("/exit_info", web::get().to(get_exit_info_http))
                     .route("/client_debt", web::post().to(get_client_debt))
                     .route("/time", web::get().to(get_exit_timestamp_http))
-                    .route("/exit_list", web::get().to(get_exit_list))
+                    .route("/exit_list", web::post().to(get_exit_list))
             })
             .workers(workers)
             .bind(format!(

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -275,6 +275,7 @@ pub fn start_rita_exit_endpoints(workers: usize) {
                     .route("/exit_info", web::get().to(get_exit_info_http))
                     .route("/client_debt", web::post().to(get_client_debt))
                     .route("/time", web::get().to(get_exit_timestamp_http))
+                    .route("/exit_list", web::get().to(get_exit_list))
             })
             .workers(workers)
             .bind(format!(

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -220,27 +220,47 @@ fn check_regions(start: Instant, clients_list: Vec<models::Client>, conn: &PgCon
 }
 
 fn setup_exit_wg_tunnel() {
+    // Setup legacy wg_exit
     if let Err(e) = KI.setup_wg_if_named("wg_exit") {
         warn!("exit setup returned {}", e)
     }
-    KI.one_time_exit_setup(
-        &settings::get_rita_exit()
-            .exit_network
-            .own_internal_ip
-            .into(),
-        settings::get_rita_exit().exit_network.netmask,
-        settings::get_rita_exit()
-            .network
-            .mesh_ip
-            .expect("Expected a mesh ip for this exit"),
-        settings::get_rita_exit()
-            .network
-            .external_nic
-            .expect("Expected an external nic here"),
+    // Setup new wg_exit
+    if let Err(e) = KI.setup_wg_if_named("wg_exit_new") {
+        warn!("new exit setup returned {}", e)
+    }
+
+    let local_ip = &settings::get_rita_exit()
+        .exit_network
+        .own_internal_ip
+        .into();
+    let netmask = settings::get_rita_exit().exit_network.netmask;
+    let mesh_ip = settings::get_rita_exit()
+        .network
+        .mesh_ip
+        .expect("Expected a mesh ip for this exit");
+    let ex_nic = settings::get_rita_exit()
+        .network
+        .external_nic
+        .expect("Expected an external nic here");
+
+    // Setup legacy wg_exit
+    KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic.clone(), "wg_exit")
+        .expect("Failed to setup wg_exit!");
+
+    // Setup new wg_exit
+    KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic, "wg_exit_new")
+        .expect("Failed to setup wg_exit_new!");
+
+    KI.setup_nat(
+        &settings::get_rita_exit().network.external_nic.unwrap(),
+        "wg_exit",
     )
-    .expect("Failed to setup wg_exit!");
-    KI.setup_nat(&settings::get_rita_exit().network.external_nic.unwrap())
-        .unwrap();
+    .unwrap();
+    KI.setup_nat(
+        &settings::get_rita_exit().network.external_nic.unwrap(),
+        "wg_exit_new",
+    )
+    .unwrap();
 }
 
 pub fn start_rita_exit_endpoints(workers: usize) {

--- a/rita_exit/src/traffic_watcher/mod.rs
+++ b/rita_exit/src/traffic_watcher/mod.rs
@@ -188,8 +188,8 @@ fn debts_logging(debts: &HashMap<Identity, i128>) {
         Ok(users) => info!("Total of {} wg_exit users online", users),
         Err(e) => warn!("Getting clients failed with {:?}", e),
     }
-    match KI.get_wg_exit_clients_online("wg_exit_new") {
-        Ok(users) => info!("Total of {} wg_exit_new users online", users),
+    match KI.get_wg_exit_clients_online("wg_exit_v2") {
+        Ok(users) => info!("Total of {} wg_exit_v2 users online", users),
         Err(e) => warn!("Getting clients failed with {:?}", e),
     }
 }
@@ -227,7 +227,7 @@ pub fn watch(
         }
     };
 
-    let new_counters = match KI.read_wg_counters("wg_exit_new") {
+    let new_counters = match KI.read_wg_counters("wg_exit_v2") {
         Ok(res) => res,
         Err(e) => {
             warn!(
@@ -326,7 +326,7 @@ pub fn watch(
     Ok(())
 }
 
-/// This function merges two counter maps for wg_exit and wg_exit_new for combined accounting
+/// This function merges two counter maps for wg_exit and wg_exit_v2 for combined accounting
 fn merge_counters(
     old_counters: &HashMap<WgKey, WgUsage>,
     new_counters: &HashMap<WgKey, WgUsage>,

--- a/scripts/openwrt_build_ipq40xx.sh
+++ b/scripts/openwrt_build_ipq40xx.sh
@@ -5,6 +5,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Parse command line arguments
 source $DIR/build_common.sh
 
-cargo install cross
+# cargo install cross
 
 cross build --target armv7-unknown-linux-musleabihf ${PROFILE} ${FEATURES} -p rita_bin --bin rita

--- a/settings/example_exit.toml
+++ b/settings/example_exit.toml
@@ -47,9 +47,9 @@ wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
 wg_private_key_path = "/tmp/exit-priv"
 
 [[exit_network.cluster_exits]]
-mesh_ip = "fd00::1"
+mesh_ip = "fd00::5"
 eth_address = "0x5AeE3Dff733F56cFe7E5390B9cC3A46a90cA1CfA"
-wg_public_key = "nGR9XhJMDNmOOzAVvZYny0SHvHyBovzod4CBUwEjajY="
+wg_public_key = "bvM10HW73yePrxdtCQQ4U20W5ogogdiZtUihrPc/oGY="
 
 [verif_settings]
 type = "Email"

--- a/settings/example_exit.toml
+++ b/settings/example_exit.toml
@@ -46,6 +46,11 @@ wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
 wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
 wg_private_key_path = "/tmp/exit-priv"
 
+[[exit_network.cluster_exits]]
+mesh_ip = "fd00::1"
+eth_address = "0x5AeE3Dff733F56cFe7E5390B9cC3A46a90cA1CfA"
+wg_public_key = "nGR9XhJMDNmOOzAVvZYny0SHvHyBovzod4CBUwEjajY="
+
 [verif_settings]
 type = "Email"
 

--- a/settings/example_exit.toml
+++ b/settings/example_exit.toml
@@ -34,7 +34,7 @@ dao_addresses = []
 
 [exit_network]
 wg_tunnel_port = 59999
-wg_new_tunnel_port = 59998
+wg_v2_tunnel_port = 59998
 exit_hello_port = 4875
 exit_price = 50
 own_internal_ip = "172.168.1.254"

--- a/settings/example_exit.toml
+++ b/settings/example_exit.toml
@@ -34,6 +34,7 @@ dao_addresses = []
 
 [exit_network]
 wg_tunnel_port = 59999
+wg_new_tunnel_port = 59998
 exit_hello_port = 4875
 exit_price = 50
 own_internal_ip = "172.168.1.254"

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -7,7 +7,6 @@ use crate::{json_merge, set_rita_client, SettingsError};
 use althea_types::wg_key::WgKey;
 use althea_types::{ContactStorage, ExitState, Identity};
 use clarity::Address;
-use ipnetwork::IpNetwork;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::path::Path;
@@ -33,8 +32,8 @@ pub fn default_config_path() -> String {
 /// ip's within the provided subnet.
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ExitServer {
-    /// Subnet of exits in cluster
-    pub subnet: IpNetwork,
+    /// Ip of exit we first connect to when connected to this cluster
+    pub root_ip: IpAddr,
 
     /// eth address of this exit cluster
     pub eth_address: Address,

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 use ipnetwork::IpNetwork;
 use phonenumber::PhoneNumber;
 use std::collections::HashSet;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 
 /// This is the network settings specific to rita_exit
@@ -47,6 +47,8 @@ pub struct ExitNetworkSettings {
     pub wg_private_key_path: String,
     /// Magic phone number operators enter in order to register to exit without auth
     pub magic_phone_number: Option<String>,
+    /// Lists of exit ip addrs in this cluster
+    pub cluster_ips: Vec<IpAddr>,
 }
 
 impl ExitNetworkSettings {
@@ -72,6 +74,7 @@ impl ExitNetworkSettings {
                 .unwrap(),
             wg_private_key_path: String::new(),
             magic_phone_number: None,
+            cluster_ips: Vec::new(),
         }
     }
 }

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -18,6 +18,7 @@ pub struct ExitNetworkSettings {
     pub exit_hello_port: u16,
     /// This is the port which the exit tunnel listens on
     pub wg_tunnel_port: u16,
+    pub wg_new_tunnel_port: u16,
     /// Price in wei per byte which is charged to traffic both coming in and out over the internet
     pub exit_price: u64,
     /// This is the exit's own ip/gateway ip in the exit wireguard tunnel
@@ -56,6 +57,7 @@ impl ExitNetworkSettings {
         ExitNetworkSettings {
             exit_hello_port: 4875,
             wg_tunnel_port: 59999,
+            wg_new_tunnel_port: 59998,
             exit_price: 10,
             own_internal_ip: "172.16.255.254".parse().unwrap(),
             exit_start_ip: "172.16.0.0".parse().unwrap(),

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -18,7 +18,7 @@ pub struct ExitNetworkSettings {
     pub exit_hello_port: u16,
     /// This is the port which the exit tunnel listens on
     pub wg_tunnel_port: u16,
-    pub wg_new_tunnel_port: u16,
+    pub wg_v2_tunnel_port: u16,
     /// Price in wei per byte which is charged to traffic both coming in and out over the internet
     pub exit_price: u64,
     /// This is the exit's own ip/gateway ip in the exit wireguard tunnel
@@ -59,7 +59,7 @@ impl ExitNetworkSettings {
         ExitNetworkSettings {
             exit_hello_port: 4875,
             wg_tunnel_port: 59999,
-            wg_new_tunnel_port: 59998,
+            wg_v2_tunnel_port: 59998,
             exit_price: 10,
             own_internal_ip: "172.16.255.254".parse().unwrap(),
             exit_start_ip: "172.16.0.0".parse().unwrap(),

--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 use ipnetwork::IpNetwork;
 use phonenumber::PhoneNumber;
 use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::Ipv4Addr;
 use std::path::Path;
 
 /// This is the network settings specific to rita_exit
@@ -48,7 +48,7 @@ pub struct ExitNetworkSettings {
     /// Magic phone number operators enter in order to register to exit without auth
     pub magic_phone_number: Option<String>,
     /// Lists of exit ip addrs in this cluster
-    pub cluster_ips: Vec<IpAddr>,
+    pub cluster_exits: Vec<Identity>,
 }
 
 impl ExitNetworkSettings {
@@ -74,7 +74,7 @@ impl ExitNetworkSettings {
                 .unwrap(),
             wg_private_key_path: String::new(),
             magic_phone_number: None,
-            cluster_ips: Vec::new(),
+            cluster_exits: Vec::new(),
         }
     }
 }

--- a/settings/test_exit.toml
+++ b/settings/test_exit.toml
@@ -30,7 +30,7 @@ default_route = []
 
 [exit_network]
 wg_tunnel_port = 59999
-wg_new_tunnel_port = 59998
+wg_v2_tunnel_port = 59998
 exit_hello_port = 4875
 exit_price = 50
 own_internal_ip = "172.168.1.254"

--- a/settings/test_exit.toml
+++ b/settings/test_exit.toml
@@ -42,6 +42,11 @@ wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
 wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
 wg_private_key_path = "/tmp/exit-priv"
 
+[[exit_network.cluster_exits]]
+mesh_ip = "fd00::1"
+eth_address = "0x5AeE3Dff733F56cFe7E5390B9cC3A46a90cA1CfA"
+wg_public_key = "nGR9XhJMDNmOOzAVvZYny0SHvHyBovzod4CBUwEjajY="
+
 [dao]
 dao_enforcement = false
 cache_timeout_seconds = 600

--- a/settings/test_exit.toml
+++ b/settings/test_exit.toml
@@ -43,9 +43,9 @@ wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
 wg_private_key_path = "/tmp/exit-priv"
 
 [[exit_network.cluster_exits]]
-mesh_ip = "fd00::1"
-eth_address = "0x5AeE3Dff733F56cFe7E5390B9cC3A46a90cA1CfA"
-wg_public_key = "nGR9XhJMDNmOOzAVvZYny0SHvHyBovzod4CBUwEjajY="
+mesh_ip = "fd00::5"
+eth_address = "0xbe398dc24de37c73cec974d688018e58f94d6e0a"
+wg_public_key = "bvM10HW73yePrxdtCQQ4U20W5ogogdiZtUihrPc/oGY="
 
 [dao]
 dao_enforcement = false

--- a/settings/test_exit.toml
+++ b/settings/test_exit.toml
@@ -30,6 +30,7 @@ default_route = []
 
 [exit_network]
 wg_tunnel_port = 59999
+wg_new_tunnel_port = 59998
 exit_hello_port = 4875
 exit_price = 50
 own_internal_ip = "172.168.1.254"


### PR DESCRIPTION
This is the first step to give exits instances unique identities. This allows for older clients to connect
to exits normally with a single ip, while newer clients can connect to a newer interfaces which allows for exit switching