### PR TITLE
Always save exit registration

### DIFF
--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -129,10 +129,10 @@ impl dyn KernelInterface {
     pub fn set_if_up_down(&self, if_name: &str, up_down: &str) -> Result<(), Error> {
         let output = self.run_command("ip", &["link", "set", "dev", if_name, up_down])?;
         if !output.stderr.is_empty() {
-            return Err(Error::RuntimeError(format!(
+            Err(Error::RuntimeError(format!(
                 "received error setting wg interface up: {}",
                 String::from_utf8(output.stderr)?
-            )));
+            )))
         } else {
             Ok(())
         }
@@ -188,10 +188,10 @@ impl dyn KernelInterface {
             &["link", "set", "dev", if_name, "mtu", &mtu.to_string()],
         )?;
         if !output.stderr.is_empty() {
-            return Err(Error::RuntimeError(format!(
+            Err(Error::RuntimeError(format!(
                 "received error setting interface mtu: {}",
                 String::from_utf8(output.stderr)?
-            )));
+            )))
         } else {
             Ok(())
         }

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -144,10 +144,9 @@ fn main() {
 
     start_rita_common_loops();
     start_rita_client_loops();
-    save_to_disk_loop(
-        SettingsOnDisk::RitaClientSettings(settings::get_rita_client()),
-        &args.flag_config,
-    );
+    save_to_disk_loop(SettingsOnDisk::RitaClientSettings(
+        settings::get_rita_client(),
+    ));
     start_core_rita_endpoints(4);
     start_rita_client_endpoints(1);
     start_client_dashboard(settings.network.rita_dashboard_port);

--- a/rita_bin/src/exit.rs
+++ b/rita_bin/src/exit.rs
@@ -70,7 +70,7 @@ fn main() {
     // load the settings file, setup a thread to save it out every so often
     // and populate the memory cache of settings used throughout the program
     let settings = {
-        let settings_file = args.flag_config.clone();
+        let settings_file = args.flag_config;
         let settings = RitaExitSettingsStruct::new_watched(&settings_file).unwrap();
 
         settings::set_git_hash(env!("GIT_HASH").to_string());
@@ -132,10 +132,9 @@ fn main() {
 
     start_rita_common_loops();
     start_rita_exit_loop();
-    save_to_disk_loop(
-        SettingsOnDisk::RitaExitSettingsStruct(settings::get_rita_exit()),
-        &args.flag_config,
-    );
+    save_to_disk_loop(SettingsOnDisk::RitaExitSettingsStruct(
+        settings::get_rita_exit(),
+    ));
 
     let workers = settings.workers;
     start_core_rita_endpoints(workers as usize);

--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -12,6 +12,7 @@ use babel_monitor::parse_routes;
 use rita_common::RitaCommonError;
 use rita_common::KI;
 use settings::client::ExitServer;
+use settings::write_config;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -149,6 +150,10 @@ pub async fn reset_exit(path: Path<String>) -> HttpResponse {
         };
         rita_client.exit_client.exits = exits;
         settings::set_rita_client(rita_client);
+        let res = write_config();
+        if let Err(e) = res {
+            error!("Failed to save exit reset! {:?}", e);
+        }
         HttpResponse::Ok().json(ret)
     } else {
         error!("Requested a reset on unknown exit {:?}", exit_name);

--- a/rita_client/src/dashboard/operator.rs
+++ b/rita_client/src/dashboard/operator.rs
@@ -3,6 +3,7 @@ use actix_web_async::web::Path;
 use actix_web_async::{HttpRequest, HttpResponse};
 use clarity::Address;
 use num256::Uint256;
+use settings::write_config;
 use std::collections::HashMap;
 
 /// TODO remove after beta 12, provided for backwards compat
@@ -28,6 +29,10 @@ pub async fn add_to_dao_list(path: Path<Address>) -> HttpResponse {
 
     rita_client.operator = operator;
     settings::set_rita_client(rita_client);
+    let res = write_config();
+    if let Err(e) = res {
+        error!("Failed to save operator address! {:?}", e);
+    }
 
     HttpResponse::Ok().finish()
 }
@@ -41,6 +46,10 @@ pub async fn remove_from_dao_list(_path: Path<Address>) -> HttpResponse {
 
     rita_client.operator = operator;
     settings::set_rita_client(rita_client);
+    let res = write_config();
+    if let Err(e) = res {
+        error!("Failed to save operator remove! {:?}", e);
+    }
 
     HttpResponse::Ok().finish()
 }
@@ -65,6 +74,10 @@ pub async fn set_dao_fee(path: Path<Uint256>) -> HttpResponse {
 
     rita_client.operator = operator;
     settings::set_rita_client(rita_client);
+    let res = write_config();
+    if let Err(e) = res {
+        error!("Failed to save operator fee! {:?}", e);
+    }
 
     HttpResponse::Ok().finish()
 }

--- a/rita_common/src/dashboard/nickname.rs
+++ b/rita_common/src/dashboard/nickname.rs
@@ -37,12 +37,10 @@ pub async fn set_nickname(nickname: Json<Nickname>) -> HttpResponse {
 
             HttpResponse::Ok().json(())
         }
-        Err(_e) => {
-            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!(
-                "{}",
-                RitaCommonError::CapacityError("Insufficient capacity for string!".to_string())
-            ));
-        }
+        Err(_e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!(
+            "{}",
+            RitaCommonError::CapacityError("Insufficient capacity for string!".to_string())
+        )),
     }
 }
 

--- a/rita_common/src/peer_listener/message.rs
+++ b/rita_common/src/peer_listener/message.rs
@@ -56,7 +56,7 @@ const MSG_HELLO: u8 = 0x6c;
 /**
  * An enum that contains all supported p2p packets
  */
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PeerMessage {
     ImHere(Ipv6Addr),
     /// This is the message sent over the udp socket. It contains the necessary information to set up a tunnel

--- a/rita_common/src/peer_listener/mod.rs
+++ b/rita_common/src/peer_listener/mod.rs
@@ -40,7 +40,7 @@ pub struct PeerListener {
 ///and when we receive a response to a hello we sent. 1 indicates we received a response hello message.
 ///This is the internal struct that carries information about local identity and which peer to send
 ///this message to, as well as whether this is a response or intial contact message.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Hello {
     pub my_id: LocalIdentity,
     pub to: Peer,

--- a/rita_common/src/rita_loop/write_to_disk.rs
+++ b/rita_common/src/rita_loop/write_to_disk.rs
@@ -1,7 +1,7 @@
 use crate::{debt_keeper::save_debt_to_disk, usage_tracker::save_usage_to_disk};
 use settings::{
     check_if_exit, client::RitaClientSettings, exit::RitaExitSettingsStruct, get_rita_client,
-    get_rita_exit, save_client_settings, save_exit_settings,
+    get_rita_exit, write_config,
 };
 use std::{
     thread,
@@ -26,8 +26,7 @@ pub enum SettingsOnDisk {
 /// is. There is also a consideration for the amount of storage the device
 /// has on disk since we don't want to save too often if the disk doesn't
 /// contain a lot of storage.
-pub fn save_to_disk_loop(mut old_settings: SettingsOnDisk, file_path: &str) {
-    let file_path = file_path.to_string();
+pub fn save_to_disk_loop(mut old_settings: SettingsOnDisk) {
     let router_storage_small;
     let saving_to_disk_frequency: Duration;
 
@@ -67,7 +66,10 @@ pub fn save_to_disk_loop(mut old_settings: SettingsOnDisk, file_path: &str) {
                 let new_settings = get_rita_client();
 
                 if old_settings_client != new_settings {
-                    save_client_settings(old_settings_client, file_path.clone());
+                    let res = write_config();
+                    if let Err(e) = res {
+                        error!("Error saving client settings! {:?}", e);
+                    }
                 }
 
                 old_settings = SettingsOnDisk::RitaClientSettings(new_settings);
@@ -76,7 +78,10 @@ pub fn save_to_disk_loop(mut old_settings: SettingsOnDisk, file_path: &str) {
                 let new_settings = get_rita_exit();
 
                 if old_settings_exit != new_settings {
-                    save_exit_settings(new_settings.clone(), file_path.clone());
+                    let res = write_config();
+                    if let Err(e) = res {
+                        error!("Error saving exit settings! {:?}", e);
+                    }
                 }
 
                 old_settings = SettingsOnDisk::RitaExitSettingsStruct(new_settings);

--- a/rita_common/src/usage_tracker/mod.rs
+++ b/rita_common/src/usage_tracker/mod.rs
@@ -61,7 +61,7 @@ pub enum UsageType {
 
 /// A struct for tracking each hour of usage, indexed by time in hours since
 /// the unix epoch
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UsageHour {
     index: u64,
     up: u64,
@@ -101,7 +101,7 @@ fn to_formatted_payment_tx(input: PaymentTx) -> FormattedPaymentTx {
 }
 
 /// A struct for tracking each hours of payments indexed in hours since unix epoch
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PaymentHour {
     index: u64,
     payments: Vec<FormattedPaymentTx>,
@@ -110,7 +110,7 @@ pub struct PaymentHour {
 /// The main actor that holds the usage state for the duration of operations
 /// at some point loading and saving will be defined in service started
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UsageTracker {
     last_save_hour: u64,
     // at least one of these will be left unused

--- a/rita_exit/src/database/database_tools.rs
+++ b/rita_exit/src/database/database_tools.rs
@@ -94,7 +94,7 @@ pub fn update_client(
             );
             diesel::update(filtered_list.clone())
                 .set(email.eq(mail))
-                .execute(&*conn)?;
+                .execute(conn)?;
         }
     }
 
@@ -106,7 +106,7 @@ pub fn update_client(
             );
             diesel::update(filtered_list.clone())
                 .set(phone.eq(number))
-                .execute(&*conn)?;
+                .execute(conn)?;
         }
     }
 
@@ -117,7 +117,7 @@ pub fn update_client(
         info!("Bumping client timestamp for {}", their_record.wg_pubkey);
         diesel::update(filtered_list)
             .set(last_seen.eq(secs_since_unix_epoch() as i64))
-            .execute(&*conn)?;
+            .execute(conn)?;
     }
 
     Ok(())
@@ -179,7 +179,7 @@ pub fn verify_client(
 
     diesel::update(filtered_list)
         .set(verified.eq(client_verified))
-        .execute(&*conn)?;
+        .execute(conn)?;
 
     Ok(())
 }
@@ -201,7 +201,7 @@ pub fn verify_db_client(
 
     diesel::update(filtered_list)
         .set(verified.eq(client_verified))
-        .execute(&*conn)?;
+        .execute(conn)?;
 
     Ok(())
 }
@@ -223,7 +223,7 @@ pub fn text_sent(
 
     diesel::update(filtered_list)
         .set(text_sent.eq(val + 1))
-        .execute(&*conn)?;
+        .execute(conn)?;
 
     Ok(())
 }
@@ -238,7 +238,7 @@ fn client_exists(client: &ExitClientIdentity, conn: &PgConnection) -> Result<boo
         .filter(mesh_ip.eq(ip.to_string()))
         .filter(wg_pubkey.eq(wg.to_string()))
         .filter(eth_address.eq(key.to_string().to_lowercase()));
-    Ok(select(exists(filtered_list)).get_result(&*conn)?)
+    Ok(select(exists(filtered_list)).get_result(conn)?)
 }
 
 /// True if there is any client with the same eth address, wg key, or ip address already registered
@@ -260,9 +260,9 @@ pub fn client_conflict(
     let ip_match = clients.filter(mesh_ip.eq(ip.to_string()));
     let wg_key_match = clients.filter(wg_pubkey.eq(wg.to_string()));
     let eth_address_match = clients.filter(eth_address.eq(key.to_string().to_lowercase()));
-    let ip_exists = select(exists(ip_match)).get_result(&*conn)?;
-    let wg_exists = select(exists(wg_key_match)).get_result(&*conn)?;
-    let eth_exists = select(exists(eth_address_match)).get_result(&*conn)?;
+    let ip_exists = select(exists(ip_match)).get_result(conn)?;
+    let wg_exists = select(exists(wg_key_match)).get_result(conn)?;
+    let eth_exists = select(exists(eth_address_match)).get_result(conn)?;
     info!(
         "Signup conflict ip {} eth {} wg {}",
         ip_exists, eth_exists, wg_exists
@@ -405,7 +405,7 @@ pub fn update_mail_sent_time(
 
     diesel::update(clients.filter(email.eq(mail_addr)))
         .set(email_sent_time.eq(secs_since_unix_epoch()))
-        .execute(&*conn)?;
+        .execute(conn)?;
 
     Ok(())
 }
@@ -614,10 +614,10 @@ pub fn get_client_subnet(
                 Ok(addr)
             } else {
                 error!("Chosen subnet: {:?} is in use! Race condition hit", addr);
-                return Err(RitaExitError::MiscStringError(format!(
+                Err(RitaExitError::MiscStringError(format!(
                     "Unable to assign user ipv6 subnet. Chosen subnet {:?} is in use",
                     addr
-                )));
+                )))
             }
         }
         Err(e) => {

--- a/rita_exit/src/database/geoip.rs
+++ b/rita_exit/src/database/geoip.rs
@@ -42,20 +42,16 @@ pub fn get_gateway_ip_single(mesh_ip: IpAddr) -> Result<IpAddr, RitaExitError> {
                         None => Err(RitaExitError::IpAddrError(mesh_ip)),
                     }
                 }
-                Err(e) => {
-                    return Err(RitaExitError::MiscStringError(format!(
-                        "Parse routes babel monitor error, {:?}",
-                        e
-                    )))
-                }
+                Err(e) => Err(RitaExitError::MiscStringError(format!(
+                    "Parse routes babel monitor error, {:?}",
+                    e
+                ))),
             }
         }
-        Err(e) => {
-            return Err(RitaExitError::MiscStringError(format!(
-                "Error opening babel stream, {:?}",
-                e
-            )));
-        }
+        Err(e) => Err(RitaExitError::MiscStringError(format!(
+            "Error opening babel stream, {:?}",
+            e
+        ))),
     }
 }
 

--- a/rita_exit/src/database/sms.rs
+++ b/rita_exit/src/database/sms.rs
@@ -83,12 +83,10 @@ async fn send_text(number: String, api_key: String) -> Result<(), RitaExitError>
         .await
     {
         Ok(_a) => Ok(()),
-        Err(e) => {
-            return Err(RitaExitError::MiscStringError(format!(
-                "Send text error: {:?}",
-                e
-            )))
-        }
+        Err(e) => Err(RitaExitError::MiscStringError(format!(
+            "Send text error: {:?}",
+            e
+        ))),
     }
 }
 

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -167,8 +167,8 @@ pub async fn secure_setup_request(
             )),
             Err(e) => {
                 error!("Signup client failed with {:?}", e);
-                return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                    .json(format!("Signup client failed with {:?}", e));
+                HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .json(format!("Signup client failed with {:?}", e))
             }
         }
     } else {

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -156,20 +156,6 @@ pub fn save_settings_on_shutdown() {
     info!("Shutdown: saving settings");
 }
 
-pub fn save_exit_settings(new_settings: RitaExitSettingsStruct, file_path: String) {
-    if let Err(e) = new_settings.write(&file_path) {
-        warn!("writing updated exit config failed {:?}", e);
-    }
-    log::info!("Exit Config/settings is being saved to");
-}
-
-pub fn save_client_settings(new_settings: RitaClientSettings, file_path: String) {
-    if let Err(e) = new_settings.write(&file_path) {
-        warn!("writing updated client config failed {:?}", e);
-    }
-    log::info!("Client Config/settings is being saved to");
-}
-
 /// get a JSON value of all settings
 pub fn get_config_json() -> Result<serde_json::Value, SettingsError> {
     match &*SETTINGS.read().unwrap() {


### PR DESCRIPTION
Specific dashboard actions where not saving instantly, like exit registration.
This patch adds saving logic for these endpoints and removes some
redundant saving functions which where only used in one location.

There is also a potential logic fix in the saving loop logic never
updating the settings on disk.