### PR TITLE
Changed serialization for OperatorUpdateMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "babel_monitor",
  "base64",
+ "bincode",
  "clarity",
  "hex",
  "ipnetwork 0.20.0",

--- a/althea_types/Cargo.toml
+++ b/althea_types/Cargo.toml
@@ -20,6 +20,7 @@ arrayvec = {version= "0.7", features = ["serde"]}
 phonenumber = "0.3"
 lettre = {version = "0.10", features = ["serde"]}
 ipnetwork = "0.20"
+bincode = "1.3"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Changed serialization for OperatorUpdateMessage to serialize as a
string to prevent the bincode serialization error. Also, wrote a unit
test to validate that there was no issue with serde.