### PR TITLE
Serde default tag added to conntrackfield in hardwareinfo struct

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -672,6 +672,7 @@ pub struct HardwareInfo {
     #[serde(default)]
     pub wifi_devices: Vec<WifiDevice>,
     // Info about the max connections, number of rows in conntrack table and current number of connections made by router
+    #[serde(default)]
     pub conntrack: Option<ConntrackInfo>,
 }
 


### PR DESCRIPTION
Without the default serde tag, the conntrack field causes an issue with deserialization which prevents ops tools to load devices correctly.