### PR TITLE
This commit adds iptables rules to intercept tcp packets and set mtu …

### DIFF
--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -256,7 +256,23 @@ impl dyn KernelInterface {
                 "--clamp-mss-to-pmtu", //should be the same as --set-mss 1300
             ],
         )?;
-        //TODO ipv6 support
+
+        //ipv6 support
+        self.add_iptables_rule(
+            "ip6tables",
+            &[
+                "-I",
+                "FORWARD",
+                "-p",
+                "tcp",
+                "--tcp-flags",
+                "SYN,RST",
+                "SYN",
+                "-j",
+                "TCPMSS",
+                "--clamp-mss-to-pmtu", //should be the same as --set-mss 1300
+            ],
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
…to althea limit

The reason we need this for ipv6 is that many servers block the icmp messages required for path mtu negotiation (PMTUD) thus breaking the internet for Althea users who have an mtu less than the default internet mtu of 1500