### PR TITLE
Added enforcement support for multiple wg interfaces and ipv6

### DIFF
--- a/rita_exit/src/database/struct_tools.rs
+++ b/rita_exit/src/database/struct_tools.rs
@@ -23,12 +23,25 @@ pub fn to_identity(client: &Client) -> Result<Identity, RitaExitError> {
 }
 
 pub fn to_exit_client(client: Client) -> Result<ExitClient, RitaExitError> {
+    let mut internet_ipv6_list = vec![];
+    let string_list: Vec<&str> = client.internet_ipv6.split(',').collect();
+    for ip_net in string_list {
+        // can we parse the ip net
+        match ip_net.parse::<IpNetwork>() {
+            Ok(ip_net) => internet_ipv6_list.push(ip_net),
+            Err(e) => error!(
+                "Unable to parse {:?}, Invalid database state? {:?}",
+                ip_net, e
+            ),
+        }
+    }
+
     Ok(ExitClient {
         mesh_ip: client.mesh_ip.parse()?,
         internal_ip: client.internal_ip.parse()?,
         port: client.wg_port as u16,
         public_key: client.wg_pubkey.parse()?,
-        internet_ipv6_list: client.internet_ipv6,
+        internet_ipv6_list,
     })
 }
 


### PR DESCRIPTION
With two wg interfaces now, qdiscs, classes and filters are duplicated for existing ipv4 tc configuartions Along with this, a new ipv6 filter is being added on both interfaces for all client classes based on their ipv6 subnet allowing for enforcement on ipv6 data also.