### PR TITLE
Modify exit htb r2q

### DIFF
--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -297,7 +297,20 @@ impl dyn KernelInterface {
         let output = self.run_command(
             "tc",
             &[
-                "qdisc", "add", "dev", iface_name, "root", "handle", "1:", "htb", "default", "0",
+                "qdisc",
+                "add",
+                "dev",
+                iface_name,
+                "root",
+                "handle",
+                "1:",
+                "htb",
+                "default",
+                "0",
+                "r2q",
+                "2",
+                "direct_qlen",
+                "100000",
             ],
         )?;
 

--- a/integration-tests/container/Dockerfile
+++ b/integration-tests/container/Dockerfile
@@ -1,14 +1,11 @@
 FROM postgres
-RUN echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
-RUN printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y sudo iputils-ping iproute2 jq vim netcat default-libmysqlclient-dev libsqlite3-dev postgresql-client-11 postgresql-server-dev-11 libpq-dev python3-pip bridge-utils wireguard linux-source curl git libssl-dev pkg-config build-essential ipset python3-setuptools python3-wheel dh-autoreconf procps
-RUN apt-get install -y -t unstable iperf3
+RUN apt-get update && apt-get install -y sudo iputils-ping iproute2 jq vim netcat default-libmysqlclient-dev libsqlite3-dev postgresql-client-11 postgresql-server-dev-11 libpq-dev python3-pip bridge-utils wireguard linux-source curl git libssl-dev pkg-config build-essential ipset python3-setuptools python3-wheel dh-autoreconf procps iperf3
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN PATH=$PATH:$HOME/.cargo/bin cargo install diesel_cli --force
 ENV POSTGRES_USER=postgres
 ENV POSTGRES_BIN=/usr/lib/postgresql/15/bin/postgres
 ENV INITDB_BIN=/usr/lib/postgresql/15/bin/initdb
-RUN PATH=$PATH:$HOME/.cargo/bin cargo install diesel_cli --force
 ARG NODES
 ENV SPEEDTEST_THROUGHPUT=$SPEEDTEST_THROUGHPUT
 ENV SPEEDTEST_DURATION=$SPEEDTEST_DURATION


### PR DESCRIPTION
This patch modifies the r2q parameter of the htb qdisc used by the exit. Read the man page 'man htb' for the full details. Essentially the "Hierarchy Token Bucket" is used to enforce on wg_exit by classifying traffic from the many differnet users going over this interface into a distinct buckets each with a given bandwidth quota.

In our case these bandwidth quotas are binary either maximum speed, or the free tier. But they are allowed to be arbitrary.

The issue being experienced here was that the r2q value was too low and thus the quantum (number of packets sent before moving on) was also too low. When under heavy load with many hundreds of users sending small packet traffic the kernel could not loop over all the buckets and fully empty them in time given the quantum (amount of packets allowed to leave the bucket per loop) implied by the r2q.

Understanding this is all well and good, but if we just look at dmesg on the exit

[28334403.750286] HTB: quantum of class 12405 is big. Consider r2q change.

We've been getting this message every time we setup wg_exit for quite some time.

This was tested by first deleting the root qdisc and running with no filters to see the nautural rate of traffic. Then htb was re-added with these parameters and traffic maintained the same nautural rate. More than double the previous rate with the higher r2q.

It remains to be seen how this will impact free tier users, by my understanding they should end up with slightly higher burst speeds before being limited down to the free tier speed limit.