### PR TITLE
WIP: Optimize exit speeds

### DIFF
--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -325,6 +325,37 @@ impl dyn KernelInterface {
         }
     }
 
+    pub fn delete_class(&self, iface_name: &str, ip: Ipv4Addr) -> Result<(), Error> {
+        let class_id = self.get_class_id(ip);
+        match self.has_class(ip, iface_name) {
+            Ok(has_class) => {
+                if has_class {
+                    self.run_command(
+                        "tc",
+                        &[
+                            "class",
+                            "del",
+                            "dev",
+                            iface_name,
+                            "parent",
+                            "1:",
+                            "classid",
+                            &format!("1:{}", class_id),
+                        ],
+                    )?;
+                }
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    "Unable to find class for ip {:?} on {:?} with {:?}",
+                    ip, iface_name, e
+                );
+                Err(e)
+            }
+        }
+    }
+
     pub fn set_class_limit(
         &self,
         iface_name: &str,
@@ -355,11 +386,6 @@ impl dyn KernelInterface {
                 &format!("{}kbit", min_bw),
                 "ceil",
                 &format!("{}kbit", max_bw),
-                // 50 packets as mtu plus 14 bytes
-                "burst",
-                "70K",
-                "quantum",
-                "1354",
             ],
         )?;
 

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -584,31 +584,34 @@ pub fn enforce_exit_clients(
         match clients_by_id.get(&debt_entry.identity) {
             Some(client) => {
                 match client.internal_ip.parse() {
+                    // TODO no ipv6 enforcement
                     Ok(IpAddr::V4(ip)) => {
-                        let res = if debt_entry.payment_details.action == DebtAction::SuspendTunnel
-                        {
+                        if debt_entry.payment_details.action == DebtAction::SuspendTunnel {
                             info!("Exit is enforcing on {} because their debt of {} is greater than the limit of {}", client.wg_pubkey, debt_entry.payment_details.debt, close_threshold);
                             if let Err(e) =
                                 KI.set_class_limit("wg_exit", free_tier_limit, free_tier_limit, ip)
                             {
                                 error!("Unable to setup enforcement class on wg_exit: {:?}", e);
                             }
-                            KI.set_class_limit("wg_exit_v2", free_tier_limit, free_tier_limit, ip)
-                        } else {
-                            // 10gbit rate and ceil value's we don't want to limit this
-                            if let Err(e) =
-                                KI.set_class_limit("wg_exit", 10_000_000, 10_000_000, ip)
-                            {
-                                error!(
-                                    "Unable to set client rate to 10GB rate on wg_exit: {:?}",
-                                    e
-                                );
+                            if let Err(e) = KI.set_class_limit(
+                                "wg_exit_v2",
+                                free_tier_limit,
+                                free_tier_limit,
+                                ip,
+                            ) {
+                                error!("Unable to setup enforcement class on wg_exit_v2: {:?}", e);
                             }
-                            KI.set_class_limit("wg_exit_v2", 10_000_000, 10_000_000, ip)
+                        } else {
+                            // Delete exisiting enforcement class, users who are not enforced are unclassifed becuase
+                            // leaving the class in place reduces their speeds.
+                            if let Err(e) = KI.delete_class("wg_exit", ip) {
+                                error!("Unable to delete class on wg_exit, is {} still enforced when they shouldnt be? {:?}", ip, e);
+                            }
+
+                            if let Err(e) = KI.delete_class("wg_exit_v2", ip) {
+                                error!("Unable to delete class on wg_exit_v2, is {} still enforced when they shouldnt be? {:?}", ip, e);
+                            }
                         };
-                        if res.is_err() {
-                            error!("Failed to limit {} with {:?}", ip, res);
-                        }
                     }
                     _ => warn!("Can't parse Ipv4Addr to create limit!"),
                 };


### PR DESCRIPTION
So the previous commit does not work at all, and it seems the main speed benefits we've been seeing mostly come from eliminating the sub-classes on traffic

The goal of this patch is to experiment with removing classes for unenforced users.