### PR TITLE
Exits advertises two mesh ip addrs

### DIFF
--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -63,6 +63,9 @@ pub struct TunnelOpenArgs<'a> {
     pub private_key_path: &'a Path,
     /// our mesh ipv6 address
     pub own_ip: IpAddr,
+    /// Exit second mesh ip used for exit roaming
+    /// This can be removed after all client migrate to Beta20 and have exit swithcing enabled
+    pub own_ip_v2: Option<IpAddr>,
     /// the nic that we use to get to the internet if we are a gateway, only used to handle
     /// default route considerations on the gateway
     pub external_nic: Option<String>,
@@ -130,6 +133,14 @@ impl dyn KernelInterface {
                 &args.interface,
             ],
         )?;
+
+        // Add second ip to tunnel for roaming
+        if let Some(ip) = args.own_ip_v2 {
+            let _output = self.run_command(
+                "ip",
+                &["address", "add", &ip.to_string(), "dev", &args.interface],
+            )?;
+        }
 
         self.run_command(
             "ip",
@@ -275,6 +286,7 @@ fe80::433:25ff:fe8c:e1ea dev eth0 lladdr 1a:32:06:78:05:0a STALE
         remote_pub_key,
         private_key_path,
         own_ip: own_mesh_ip,
+        own_ip_v2: None,
         external_nic: None,
         settings_default_route: &mut Some(def_route),
         allowed_ipv4_address: None,

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -587,6 +587,14 @@ pub struct ShaperSettings {
     pub min_speed: usize,
 }
 
+/// This struct is sent up to op to display info related to a routers connect exit there
+#[derive(Default, Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct CurExitInfo {
+    pub cluster_name: Option<String>,
+    pub instance_name: Option<String>,
+    pub instance_ip: Option<String>,
+}
+
 fn default_shaper_settings() -> ShaperSettings {
     ShaperSettings {
         max_speed: 1000,
@@ -606,6 +614,8 @@ pub struct OperatorCheckinMessage {
     /// we don't know what this router is supposed to be configured like, the best
     /// proxy for that is the system chain value
     pub system_chain: SystemChain,
+    /// Infomation about current exit
+    pub cur_exit: Option<CurExitInfo>,
     /// The status of this devices peers, this is data that we want to communicate
     /// with the operator server but don't really have space in the purely udp
     /// heartbeat packet, neither is it required that this data be sent very often

--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -4,6 +4,7 @@ pub mod updater;
 extern crate openssh_keys;
 use crate::dashboard::system_chain::set_system_blockchain;
 use crate::dashboard::wifi::reset_wifi_pass;
+use crate::exit_manager::get_selected_exit;
 use crate::rita_loop::is_gateway_client;
 use crate::rita_loop::CLIENT_LOOP_TIMEOUT;
 use crate::set_router_update_instruction;
@@ -13,6 +14,7 @@ use althea_types::AuthorizedKeys;
 use althea_types::BillingDetails;
 use althea_types::ContactStorage;
 use althea_types::ContactType;
+use althea_types::CurExitInfo;
 use althea_types::HardwareInfo;
 use althea_types::OperatorAction;
 use althea_types::OperatorCheckinMessage;
@@ -153,6 +155,18 @@ pub async fn operator_update() {
 
     hardware_info_logs(&hardware_info);
 
+    // Get current exit info
+    let cur_cluster = settings::get_rita_client().exit_client.current_exit;
+    let cur_exit = Some(CurExitInfo {
+        cluster_name: cur_cluster.clone(),
+        // Hopefully ops fills this in
+        instance_name: None,
+        instance_ip: match cur_cluster {
+            Some(a) => get_selected_exit(a).map(|a| a.to_string()),
+            None => None,
+        },
+    });
+
     let client = awc::Client::default();
     let response = client
         .post(url)
@@ -161,6 +175,7 @@ pub async fn operator_update() {
             id,
             operator_address,
             system_chain,
+            cur_exit,
             neighbor_info,
             contact_info,
             install_details,

--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -167,6 +167,7 @@ impl Tunnel {
                     ))
                 }
             },
+            own_ip_v2: network.mesh_ip_v2,
             external_nic: network.external_nic.clone(),
             settings_default_route: &mut network.last_default_route,
             allowed_ipv4_address: light_client_details,

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -288,7 +288,7 @@ fn setup_exit_wg_tunnel() {
     KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic.clone(), "wg_exit")
         .expect("Failed to setup wg_exit!");
 
-    // Setup new wg_exit
+    // Setup new wg_exit. Local address added is same as that used by wg_exit
     KI.one_time_exit_setup(local_ip, netmask, mesh_ip, ex_nic, "wg_exit_v2")
         .expect("Failed to setup wg_exit_v2!");
 

--- a/settings/src/network.rs
+++ b/settings/src/network.rs
@@ -41,6 +41,9 @@ pub struct NetworkSettings {
     /// The static IP used on mesh interfaces
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh_ip: Option<IpAddr>,
+    /// MeshIp used by new routers to allow for exit switching
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mesh_ip_v2: Option<IpAddr>,
     /// Broadcast ip address used for peer discovery (in ff02::/8)
     #[serde(default = "default_discovery_ip")]
     pub discovery_ip: Ipv6Addr,
@@ -121,6 +124,7 @@ impl Default for NetworkSettings {
             backup_created: false,
             metric_factor: default_metric_factor(),
             mesh_ip: None,
+            mesh_ip_v2: None,
             discovery_ip: default_discovery_ip(),
             babel_port: 6872,
             rita_contact_port: 4874,


### PR DESCRIPTION
In continuation of setting up exit roaming and switching, in order to add backward compatibility between b19 and b20 routers, two wg exit interfaces were added. This commit continues that by getting the exit to advertise two ip addrs, one for b19 routers to connect to as normal, and one for b20 routers to allow for exit roaming B20 routers retrieve a list of IP addrs from an exit and uses these ips to migrate between exits. Since all b19 routers are connected on a seperate ip this should not affect them.