### PR TITLE
Change order of ip on wg tunnels

### DIFF
--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -123,6 +123,15 @@ impl dyn KernelInterface {
                 String::from_utf8(output.stderr)?
             )));
         }
+
+        // Add second ip to tunnel for roaming
+        if let Some(ip) = args.own_ip_v2 {
+            let _output = self.run_command(
+                "ip",
+                &["address", "add", &ip.to_string(), "dev", &args.interface],
+            )?;
+        }
+
         let _output = self.run_command(
             "ip",
             &[
@@ -133,14 +142,6 @@ impl dyn KernelInterface {
                 &args.interface,
             ],
         )?;
-
-        // Add second ip to tunnel for roaming
-        if let Some(ip) = args.own_ip_v2 {
-            let _output = self.run_command(
-                "ip",
-                &["address", "add", &ip.to_string(), "dev", &args.interface],
-            )?;
-        }
 
         self.run_command(
             "ip",


### PR DESCRIPTION
It was noticed that having the new ip first would make b19 routers connect to the new ip, causing payment issues. This is done in hopes of getting wg_exit to handshake only over the old ip