### PR TITLE
Use exit manager's selected ip to query debts

### DIFF
--- a/rita_client/src/exit_manager/mod.rs
+++ b/rita_client/src/exit_manager/mod.rs
@@ -39,6 +39,7 @@ use futures::future::join_all;
 use futures::join;
 use ipnetwork::IpNetwork;
 use rita_common::blockchain_oracle::low_balance;
+use rita_common::payment_controller::set_payment_exit_list;
 use rita_common::KI;
 use settings::client::{ExitServer, SelectedExit};
 use sodiumoxide::crypto::box_;
@@ -808,7 +809,8 @@ pub async fn exit_manager_tick() {
                 exit_list
             );
             let exit_wg_port = exit_list.wg_exit_listen_port;
-            let is_valid = set_exit_list(exit_list);
+            let is_valid = set_exit_list(exit_list.clone());
+            set_payment_exit_list(exit_list.exit_list);
             // When the list is empty or the port is 0, the exit services us
             // an invalid struct or we made a bad request
             if !is_valid || exit_wg_port == 0 {

--- a/rita_client/src/traffic_watcher/mod.rs
+++ b/rita_client/src/traffic_watcher/mod.rs
@@ -96,14 +96,13 @@ pub async fn query_exit_debts(msg: QueryExitDebts) {
     }
     let gateway_exit_client = is_gateway_client();
     let start = Instant::now();
-    let exit_addr = msg.exit_internal_addr;
     let exit_id = msg.exit_id;
     let exit_port = msg.exit_port;
     // actix client behaves badly if you build a request the default way but don't give it
     // a domain name, so in order to do peer to peer requests we use with_connection and our own
     // socket specification
     let our_id = settings::get_rita_client().get_identity();
-    let request = format!("http://{}:{}/client_debt", exit_addr, exit_port);
+    let request = format!("http://[{}]:{}/client_debt", exit_id.mesh_ip, exit_port);
     // it's an ipaddr appended to a u16, there's no real way for this to fail
     // unless of course it's an ipv6 address and you don't do the []
 

--- a/rita_common/src/network_endpoints/mod.rs
+++ b/rita_common/src/network_endpoints/mod.rs
@@ -1,5 +1,6 @@
 //! Network endptoints for common Rita functionality (such as exchanging hello messages)
 
+use crate::payment_controller::get_all_payment_txids;
 use crate::payment_validator::{validate_later, ToValidate};
 use crate::peer_listener::Peer;
 use crate::tm_identity_callback;
@@ -10,6 +11,7 @@ use actix_web_async::web::Json;
 
 use actix_web_async::{HttpRequest, HttpResponse};
 use althea_types::{LocalIdentity, PaymentTx};
+use std::collections::HashSet;
 use std::time::Instant;
 
 /// The recieve side of the make payments call
@@ -43,6 +45,59 @@ pub async fn make_payments(item: Json<PaymentTx>) -> HttpResponse {
     validate_later(ts);
 
     HttpResponse::Ok().json("Payment Received!")
+}
+
+/// This endpoint takes a list of payments from a sender and compares it to our own received list.
+/// Sends all unaccounted payments to the payment validator
+pub async fn make_payments_v2(item: Json<HashSet<PaymentTx>>) -> HttpResponse {
+    let pmt_list = item.into_inner();
+    let our_address = settings::get_rita_common().payment.eth_address.unwrap();
+    let mut from_list: HashSet<PaymentTx>;
+    let mut response_builder: String = String::new();
+
+    for pmt in pmt_list {
+        from_list = get_all_payment_txids(pmt.from, false);
+
+        if !from_list.contains(&pmt) {
+            let txid = pmt.txid.clone();
+            // we didn't get a txid, probably an old client.
+            // why don't we need an Either up here? Because the types ultimately match?
+            if txid.is_none() {
+                error!("Did not find txid, payment failed!");
+                response_builder.push_str("txid not provided! Invalid payment!\n");
+                continue;
+            } else if pmt.to.eth_address != our_address {
+                response_builder.push_str(&format!(
+                    "We are not {} our address is {}! Invalid payment with txid {:#066x}\n",
+                    pmt.to.eth_address,
+                    our_address,
+                    txid.clone().unwrap()
+                ));
+                continue;
+            }
+            let txid = txid.unwrap();
+            info!(
+                "Got Payment from {} for {} with txid {:#066x}",
+                pmt.from.wg_public_key, pmt.amount, txid,
+            );
+            response_builder.push_str(&format!(
+                "Got Payment from {} for {} with txid {:#066x}",
+                pmt.from.wg_public_key, pmt.amount, txid,
+            ));
+            let ts = ToValidate {
+                payment: pmt,
+                received: Instant::now(),
+                checked: false,
+            };
+            validate_later(ts);
+        }
+    }
+
+    if !response_builder.contains("Invalid") {
+        HttpResponse::Ok().json("Payments Received!")
+    } else {
+        HttpResponse::build(StatusCode::from_u16(400u16).unwrap()).json(&response_builder)
+    }
 }
 
 pub async fn hello_response(item: Json<LocalIdentity>, req: HttpRequest) -> HttpResponse {

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -3,13 +3,15 @@
 //! until it is successfully in a block, see payment_validator, once the payment is on
 //! the blockchain it's up to the reciever to validate that it's correct
 
-use althea_types::PaymentTx;
+use althea_types::{Identity, PaymentTx};
 use awc;
 use futures::future::join_all;
 use num256::Uint256;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Result as DisplayResult;
 use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::time::Instant;
@@ -43,6 +45,16 @@ pub struct PaymentController {
     /// info over to our neighbor. Even if we fail to do so we should still consider
     /// this debt as paid
     resend_queue: Vec<ResendInfo>,
+    /// This datastore saves the payment receipts made from the start of rita
+    /// This can be used to send to exits and neighbors when making a payment
+    /// and can be used to synchronize transaction data in the cases of erroneous
+    /// payments
+    /// This is stored in the form of a hashmap key: recepient id -> value: list of payment tx
+    payment_sent_datastore: HashMap<Identity, HashSet<PaymentTx>>,
+    /// Same as above, stored as key: sender id -> value: list of payment tx
+    payment_received_datastore: HashMap<Identity, HashSet<PaymentTx>>,
+    /// A copy of Rita Client's exit list. This stays empty in the case of an exit
+    exit_list: Vec<Identity>,
 }
 
 /// Pushes a payment tx onto the payment controller queue, to be processed
@@ -61,11 +73,78 @@ fn queue_resend(resend_info: ResendInfo) {
     data.resend_queue.push(resend_info);
 }
 
+///This function stores an outgoing payment in payment datastore. We store both sent and received payments
+pub fn store_payment(pmt: PaymentTx, sent: bool) {
+    let mut lock = PAYMENT_DATA.write().unwrap();
+    let neighbor;
+    let data = if sent {
+        neighbor = pmt.to;
+        &mut lock.payment_sent_datastore
+    } else {
+        neighbor = pmt.from;
+        &mut lock.payment_received_datastore
+    };
+
+    if let std::collections::hash_map::Entry::Vacant(e) = data.entry(neighbor) {
+        let mut set = HashSet::new();
+        set.insert(pmt);
+        e.insert(set);
+    } else {
+        let set = data
+            .get_mut(&neighbor)
+            .expect("This key should have an initialized set");
+        set.insert(pmt);
+    }
+}
+
+/// Incase payment validator invalidates a transaction, we remove it from our list
+pub fn remove_invalid_payment(pmt: PaymentTx) {
+    let data = &mut PAYMENT_DATA.write().unwrap().payment_sent_datastore;
+    let to = pmt.to;
+
+    if let Some(list) = data.get_mut(&to) {
+        list.remove(&pmt);
+    }
+}
+
+/// Given a payment identity, get either all payments sent to that identity or all payments received from that
+/// id
+pub fn get_all_payment_txids(addr: Identity, sent: bool) -> HashSet<PaymentTx> {
+    let lock = PAYMENT_DATA.read().unwrap();
+    let data = if sent {
+        lock.payment_sent_datastore.get(&addr)
+    } else {
+        lock.payment_received_datastore.get(&addr)
+    };
+
+    match data {
+        Some(set) => set.clone(),
+        None => {
+            error!(
+                "No hashset for the payment address {:?}, returning empty set",
+                addr
+            );
+            HashSet::new()
+        }
+    }
+}
+
+pub fn set_payment_exit_list(list: Vec<Identity>) {
+    PAYMENT_DATA.write().unwrap().exit_list = list;
+}
+
+pub fn get_payment_exit_list() -> Vec<Identity> {
+    PAYMENT_DATA.read().unwrap().exit_list.clone()
+}
+
 impl PaymentController {
     pub fn new() -> Self {
         PaymentController {
             outgoing_queue: Vec::new(),
             resend_queue: Vec::new(),
+            payment_sent_datastore: HashMap::new(),
+            payment_received_datastore: HashMap::new(),
+            exit_list: Vec::new(),
         }
     }
 }
@@ -145,7 +224,6 @@ pub async fn tick_payment_controller() {
 /// PaymentTx to the `mesh_ip` in its `to` field.
 async fn make_payment(mut pmt: PaymentTx) -> Result<(), PaymentControllerError> {
     let common = settings::get_rita_common();
-    let network_settings = common.network;
     let payment_settings = common.payment;
     let balance = get_oracle_balance();
     let nonce = get_oracle_nonce();
@@ -186,16 +264,6 @@ async fn make_payment(mut pmt: PaymentTx) -> Result<(), PaymentControllerError> 
             });
         }
     }
-
-    // testing hack
-    let neighbor_url = if cfg!(not(test)) {
-        format!(
-            "http://[{}]:{}/make_payment",
-            pmt.to.mesh_ip, network_settings.rita_contact_port,
-        )
-    } else {
-        String::from("http://127.0.0.1:1234/make_payment")
-    };
 
     let full_node = get_web3_server();
     let web3 = Web3::new(&full_node, TRANSACTION_SUBMISSION_TIMEOUT);
@@ -238,6 +306,145 @@ async fn make_payment(mut pmt: PaymentTx) -> Result<(), PaymentControllerError> 
     // add published txid to submission
     pmt.txid = Some(tx_id.clone());
 
+    // Add new payment to Hashmap of transactions
+    store_payment(pmt.clone(), true);
+
+    // special case when paying exit, we sent our transaction to all exits
+    // This is important in the case of exit switching, since we have only one entry
+    // of exit in debt keeper, but all exits in a cluster have an entry for us
+    // Payment validator on the exit will make sure the right exit accepts the transaction
+    // The client may be credited more than it should, this will be fixed once exits have their own
+    // eth payment addresses
+    if are_we_paying_exit(pmt.clone()) {
+        info!(
+            "Sending bw payment with txid {:#066x} to all exits in \n{:?}",
+            tx_id,
+            get_payment_exit_list()
+        );
+        for exit in get_payment_exit_list() {
+            // Call endpoint make_payment_v2, which should validate all payments made since restart. If this fails,
+            // the node we are paying is b19 and we call make_payment
+            if let Err(e) =
+                send_make_payment_endpoint_v2(pmt.clone(), full_node.clone(), exit.mesh_ip).await
+            {
+                warn!(
+                    "Cannot hit make_payment_v2 endpoint for pmt transaction {:?} with error {}",
+                    pmt.clone(),
+                    e
+                );
+                send_make_payment_endpoint(pmt.clone(), full_node.clone(), exit.mesh_ip).await;
+            }
+        }
+    } else {
+        // We are paying a neighbor
+        if let Err(e) =
+            send_make_payment_endpoint_v2(pmt.clone(), full_node.clone(), pmt.to.mesh_ip).await
+        {
+            warn!(
+                "Cannot hit make_payment_v2 endpoint for pmt transaction {:?} with error {}",
+                pmt.clone(),
+                e
+            );
+            send_make_payment_endpoint(pmt.clone(), full_node, pmt.to.mesh_ip).await;
+        }
+    }
+
+    // place this payment in the validation queue to handle later.
+    let ts = ToValidate {
+        payment: pmt,
+        received: Instant::now(),
+        checked: false,
+    };
+
+    validate_later(ts);
+
+    Ok(())
+}
+
+/// This function check if payment.to.mesh_ip is a mesh ip in our exit list
+fn are_we_paying_exit(pmt: PaymentTx) -> bool {
+    let list = get_payment_exit_list();
+    let to = pmt.to;
+
+    for exit in list {
+        if exit.mesh_ip == to.mesh_ip {
+            return true;
+        }
+    }
+    false
+}
+
+async fn send_make_payment_endpoint_v2(
+    pmt: PaymentTx,
+    full_node: String,
+    mesh_ip: IpAddr,
+) -> Result<(), PaymentControllerError> {
+    let common = settings::get_rita_common();
+    let network_settings = common.network;
+    let latest_txid = pmt.txid.expect("Why did we fail to setup txid");
+    let neighbor_url_v2 = if cfg!(not(test)) {
+        format!(
+            "http://[{}]:{}/make_payment_v2",
+            mesh_ip, network_settings.rita_contact_port,
+        )
+    } else {
+        String::from("http://127.0.0.1:1234/make_payment_v2")
+    };
+
+    let actix_client = awc::Client::new();
+    let neigh_ack_v2 = actix_client
+        .post(neighbor_url_v2.clone())
+        .timeout(TRANSACTION_SUBMISSION_TIMEOUT)
+        .send_json(&get_all_payment_txids(pmt.to, true))
+        .await;
+
+    match neigh_ack_v2 {
+        Ok(mut val) => {
+            if val.status().is_success() {
+                info!(
+                    "Payment pmt with latest txid: {:#066x} is sent to our neighbor with status {:?} and body {:?} via url {}, using full node {} and amount {:?}",
+                    latest_txid,
+                    val.status(),
+                    val.body().await,
+                    neighbor_url_v2,
+                    full_node,
+                    pmt.amount
+                );
+                Ok(())
+            } else {
+                error!(
+            "We published latest txid: {:#066x} but our neighbor responded with status {:?} and body {:?}",
+            latest_txid, val.status(), val.body().await);
+                Err(PaymentControllerError::FailedToSendPayment)
+            }
+        }
+        Err(e) => {
+            error!(
+                "We published latest txid: {:#066x} but failed to notify our neighbor with {:?}",
+                latest_txid, e
+            );
+            Err(PaymentControllerError::FailedToSendPayment)
+        }
+    }
+}
+
+async fn send_make_payment_endpoint(pmt: PaymentTx, full_node: String, mesh_ip: IpAddr) {
+    let pmt_clone = pmt.clone();
+    let common = settings::get_rita_common();
+    let network_settings = common.network;
+    let tx_id = pmt_clone
+        .txid
+        .expect("Why did this fail when we set this to Some(val)");
+
+    let neighbor_url = if cfg!(not(test)) {
+        format!(
+            "http://[{}]:{}/make_payment",
+            mesh_ip, network_settings.rita_contact_port,
+        )
+    } else {
+        String::from("http://127.0.0.1:1234/make_payment")
+    };
+
     let actix_client = awc::Client::new();
     let neigh_ack = actix_client
         .post(neighbor_url.clone())
@@ -279,17 +486,6 @@ async fn make_payment(mut pmt: PaymentTx) -> Result<(), PaymentControllerError> 
             queue_resend(resend_info)
         }
     }
-
-    // place this payment in the validation queue to handle later.
-    let ts = ToValidate {
-        payment: pmt,
-        received: Instant::now(),
-        checked: false,
-    };
-
-    validate_later(ts);
-
-    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -328,4 +524,86 @@ async fn resend_txid(input: ResendInfo) -> Result<(), PaymentControllerError> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_payment_txid_datastore() {
+    let client_id = Identity {
+        mesh_ip: "fd00::1".parse().unwrap(),
+        eth_address: "0xE39bDB2e345ACf7B0C7B1A28dFA26288C3094A6A"
+            .parse()
+            .unwrap(),
+        wg_public_key: "NZnbEv9w5lC3JG3hacwh5cq8C5NnsAUJLrNKYL91fS0="
+            .parse()
+            .unwrap(),
+        nickname: None,
+    };
+
+    let exit_id = Identity {
+        mesh_ip: "fd00::1337".parse().unwrap(),
+        eth_address: "0xE39bDB2e345ACf7B0C7B1A28dFA26288C3094A6A"
+            .parse()
+            .unwrap(),
+        wg_public_key: "PiMD6fCsgyNKwz9AVqP/GRT3+o6h6e9Y0KPEdFct/yw="
+            .parse()
+            .unwrap(),
+        nickname: None,
+    };
+
+    let mut sent_hashset = HashSet::new();
+    let mut rec_hashset: HashSet<PaymentTx> = HashSet::new();
+
+    let pmt1 = PaymentTx {
+        to: exit_id,
+        from: client_id,
+        amount: 10u8.into(),
+        txid: Some(1u8.into()),
+    };
+    store_payment(pmt1.clone(), true);
+    sent_hashset.insert(pmt1.clone());
+    assert_eq!(get_all_payment_txids(pmt1.to, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt1.to, false), HashSet::new());
+
+    let pmt2 = PaymentTx {
+        to: exit_id,
+        from: client_id,
+        amount: 100u8.into(),
+        txid: Some(2u8.into()),
+    };
+    store_payment(pmt2.clone(), true);
+    sent_hashset.insert(pmt2.clone());
+    assert_eq!(get_all_payment_txids(pmt2.to, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt2.to, false), HashSet::new());
+
+    let pmt3 = PaymentTx {
+        to: client_id,
+        from: exit_id,
+        amount: 80u8.into(),
+        txid: Some(3u8.into()),
+    };
+    store_payment(pmt3.clone(), false);
+    rec_hashset.insert(pmt3.clone());
+    assert_eq!(get_all_payment_txids(pmt3.from, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt3.from, false), rec_hashset);
+
+    let pmt4 = PaymentTx {
+        to: client_id,
+        from: exit_id,
+        amount: 30u8.into(),
+        txid: Some(4u8.into()),
+    };
+    store_payment(pmt4.clone(), false);
+    rec_hashset.insert(pmt4.clone());
+    assert_eq!(get_all_payment_txids(pmt4.from, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt4.from, false), rec_hashset);
+
+    remove_invalid_payment(pmt1.clone());
+    sent_hashset.remove(&pmt1);
+    assert_eq!(get_all_payment_txids(pmt1.to, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt1.to, false), rec_hashset);
+
+    remove_invalid_payment(pmt2.clone());
+    sent_hashset.remove(&pmt2);
+    assert_eq!(get_all_payment_txids(pmt2.to, true), sent_hashset);
+    assert_eq!(get_all_payment_txids(pmt2.to, false), rec_hashset);
 }

--- a/rita_common/src/rita_loop/mod.rs
+++ b/rita_common/src/rita_loop/mod.rs
@@ -78,7 +78,9 @@ pub fn start_core_rita_endpoints(workers: usize) {
 
             // Rita accept payment function, on a different port
             let res = HttpServer::new(|| {
-                App::new().route("/make_payment", web::post().to(make_payments))
+                App::new()
+                    .route("/make_payment", web::post().to(make_payments))
+                    .route("/make_payment_v2", web::post().to(make_payments_v2))
             })
             .workers(workers)
             .bind(format!("[::0]:{}", common.network.rita_contact_port))


### PR DESCRIPTION
This matters when we have a router that have two exits in a cluster in manual peers, we need to ensure we are querying and paying the correct exit in the cluster