### PR TITLE
Remove return on status error for opkg update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "rita_bin"
-version = "0.20.8"
+version = "0.20.9"
 dependencies = [
  "actix 0.13.0",
  "actix-web",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "rita_client"
-version = "0.20.8"
+version = "0.20.9"
 dependencies = [
  "actix 0.13.0",
  "actix-web",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "rita_common"
-version = "0.20.8"
+version = "0.20.9"
 dependencies = [
  "actix 0.13.0",
  "actix-service",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "rita_exit"
-version = "0.20.8"
+version = "0.20.9"
 dependencies = [
  "actix 0.13.0",
  "actix-web",

--- a/rita_client/src/operator_update/updater.rs
+++ b/rita_client/src/operator_update/updater.rs
@@ -19,11 +19,10 @@ pub fn update_system(instruction: UpdateType) -> Result<(), KernelInterfaceError
                     let res = KI.perform_opkg(cmd);
                     match res {
                         Ok(o) => match o.status.code() {
-                            Some(0) => info!("opkg update completed successfully! {:?}", o),
+                            Some(0) => info!("opkg completed successfully! {:?}", o),
                             Some(_) => {
-                                let err = format!("opkg update has failed! {:?}", o);
+                                let err = format!("opkg has failed! {:?}", o);
                                 error!("{}", err);
-                                return Err(KernelInterfaceError::RuntimeError(err));
                             }
                             None => warn!("No return code form opkg update? {:?}", o),
                         },


### PR DESCRIPTION
Output of opkg update always returns an error since opkg cannot download our customfeed url. Returning in this case would not run opkg install and stop the update process. We should continue to try to run opkg even after an error