### PR TITLE
Revamp the token bridge module

### DIFF
--- a/althea_kernel_interface/src/create_wg_key.rs
+++ b/althea_kernel_interface/src/create_wg_key.rs
@@ -17,7 +17,7 @@ impl dyn KernelInterface {
     pub fn create_wg_key(&self, path: &Path, private_key: &WgKey) -> Result<(), Error> {
         trace!("Overwriting old private key file");
         let mut priv_key_file = File::create(path)?;
-        write!(priv_key_file, "{}", private_key)?;
+        write!(priv_key_file, "{private_key}")?;
         Ok(())
     }
 

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -63,10 +63,7 @@ impl dyn KernelInterface {
         // tunnel
         for i in self.get_peers("wg_exit")? {
             if i != args.pubkey {
-                self.run_command(
-                    "wg",
-                    &["set", "wg_exit", "peer", &format!("{}", i), "remove"],
-                )?;
+                self.run_command("wg", &["set", "wg_exit", "peer", &format!("{i}"), "remove"])?;
             }
         }
 

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -31,7 +31,7 @@ impl dyn KernelInterface {
             "set".into(),
             if_name.into(),
             "listen-port".into(),
-            format!("{}", listen_port),
+            format!("{listen_port}"),
             "private-key".into(),
             private_key_path.to_string(),
         ];
@@ -70,7 +70,7 @@ impl dyn KernelInterface {
         for i in wg_peers {
             if !client_pubkeys.contains(&i) {
                 warn!("Removing no longer authorized peer {}", i);
-                self.run_command("wg", &["set", if_name, "peer", &format!("{}", i), "remove"])?;
+                self.run_command("wg", &["set", if_name, "peer", &format!("{i}"), "remove"])?;
             }
         }
 
@@ -287,7 +287,7 @@ impl dyn KernelInterface {
             &[
                 "address",
                 "add",
-                &format!("{}/{}", local_ip, netmask),
+                &format!("{local_ip}/{netmask}"),
                 "dev",
                 interface,
             ],
@@ -301,7 +301,7 @@ impl dyn KernelInterface {
             &[
                 "address",
                 "add",
-                &format!("{}/64", local_link),
+                &format!("{local_link}/64"),
                 "dev",
                 interface,
             ],
@@ -431,7 +431,7 @@ fn test_iproute_parsing() {
     for ip in ipv6_list {
         // Verfiy its a valid subnet
         if let Ok(ip_net) = ip.parse::<IpNetwork>() {
-            println!("debugging: {:?}", ip_net)
+            println!("debugging: {ip_net:?}")
         }
     }
 }

--- a/althea_kernel_interface/src/file_io.rs
+++ b/althea_kernel_interface/src/file_io.rs
@@ -24,7 +24,7 @@ pub fn write_out(filename: &str, content: Vec<String>) -> Result<(), Error> {
     let mut file = File::create(filename)?;
     let mut final_output = String::new();
     for item in content {
-        writeln!(final_output, "{}", item).unwrap();
+        writeln!(final_output, "{item}").unwrap();
     }
     file.write_all(final_output.as_bytes())?;
     Ok(())

--- a/althea_kernel_interface/src/hardware_info.rs
+++ b/althea_kernel_interface/src/hardware_info.rs
@@ -261,23 +261,23 @@ fn get_sensor_readings() -> Option<Vec<SensorReading>> {
     // sensors are zero indexed and there will never be gaps
     let mut sensor_num = 0;
     let mut ret = Vec::new();
-    let mut path = format!("/sys/class/hwmon/hwmon{}", sensor_num);
+    let mut path = format!("/sys/class/hwmon/hwmon{sensor_num}");
     while fs::metadata(path.clone()).is_ok() {
         if let (Some(reading), Some(name)) = (
-            maybe_get_single_line_u64(&format!("{}/temp1_input", path)),
-            maybe_get_single_line_string(&format!("{}/name", path)),
+            maybe_get_single_line_u64(&format!("{path}/temp1_input")),
+            maybe_get_single_line_string(&format!("{path}/name")),
         ) {
             ret.push(SensorReading {
                 name,
                 reading,
-                min: maybe_get_single_line_u64(&format!("{}/temp1_min", path)),
-                crit: maybe_get_single_line_u64(&format!("{}/temp1_crit", path)),
-                max: maybe_get_single_line_u64(&format!("{}/temp1_max", path)),
+                min: maybe_get_single_line_u64(&format!("{path}/temp1_min")),
+                crit: maybe_get_single_line_u64(&format!("{path}/temp1_crit")),
+                max: maybe_get_single_line_u64(&format!("{path}/temp1_max")),
             });
         }
 
         sensor_num += 1;
-        path = format!("/sys/class/hwmon/hwmon{}", sensor_num);
+        path = format!("/sys/class/hwmon/hwmon{sensor_num}");
     }
     if ret.is_empty() {
         None
@@ -289,13 +289,13 @@ fn get_sensor_readings() -> Option<Vec<SensorReading>> {
 fn get_ethernet_stats() -> Option<Vec<EthernetStats>> {
     let mut eth = 0;
     let mut ret = Vec::new();
-    let mut path = format!("/sys/class/net/eth{}", eth);
+    let mut path = format!("/sys/class/net/eth{eth}");
     while fs::metadata(path.clone()).is_ok() {
-        if let Some(is_up) = maybe_get_single_line_string(&format!("{}/operstate", path)) {
+        if let Some(is_up) = maybe_get_single_line_string(&format!("{path}/operstate")) {
             let is_up = is_up.contains("up");
             if let (Some(speed), Some(duplex)) = (
-                maybe_get_single_line_u64(&format!("{}/speed", path)),
-                maybe_get_single_line_string(&format!("{}/duplex", path)),
+                maybe_get_single_line_u64(&format!("{path}/speed")),
+                maybe_get_single_line_string(&format!("{path}/duplex")),
             ) {
                 if let (
                     Some(tx_errors),
@@ -303,10 +303,10 @@ fn get_ethernet_stats() -> Option<Vec<EthernetStats>> {
                     Some(tx_packet_count),
                     Some(rx_packet_count),
                 ) = (
-                    maybe_get_single_line_u64(&format!("{}/statistics/tx_errors", path)),
-                    maybe_get_single_line_u64(&format!("{}/statistics/rx_errors", path)),
-                    maybe_get_single_line_u64(&format!("{}/statistics/tx_packets", path)),
-                    maybe_get_single_line_u64(&format!("{}/statistics/rx_packets", path)),
+                    maybe_get_single_line_u64(&format!("{path}/statistics/tx_errors")),
+                    maybe_get_single_line_u64(&format!("{path}/statistics/rx_errors")),
+                    maybe_get_single_line_u64(&format!("{path}/statistics/tx_packets")),
+                    maybe_get_single_line_u64(&format!("{path}/statistics/rx_packets")),
                 ) {
                     ret.push(EthernetStats {
                         is_up,
@@ -320,7 +320,7 @@ fn get_ethernet_stats() -> Option<Vec<EthernetStats>> {
             }
         }
         eth += 1;
-        path = format!("/sys/class/net/eth{}", eth);
+        path = format!("/sys/class/net/eth{eth}");
     }
 
     if ret.is_empty() {
@@ -477,13 +477,13 @@ mod test {
     #[test]
     fn test_sensors() {
         let res = get_sensor_readings();
-        println!("{:?}", res);
+        println!("{res:?}");
     }
 
     #[test]
     fn test_ethernet_stats() {
         let res = get_ethernet_stats();
-        println!("{:?}", res);
+        println!("{res:?}");
     }
 
     #[test]
@@ -506,41 +506,26 @@ mod test {
     fn test_kernel_version_temp() {
         let res = parse_kernel_version("Linux version 4.19.78-coreos (jenkins@ip-10-7-32-103) (gcc version 8.3.0 (Gentoo Hardened 8.3.0-r1 p1.1)) #1 SMP Mon Oct 14 22:56:39 -00 2019".to_string());
         let (str1, str2) = res.unwrap();
-        println!(
-            "Entire Kernel String: {} \nKernel String:{}\n\n",
-            str1, str2
-        );
+        println!("Entire Kernel String: {str1} \nKernel String:{str2}\n\n");
 
         let res = parse_kernel_version("".to_string());
         let (str1, str2) = res.unwrap();
-        println!(
-            "Entire Kernel String: {} \nKernel String:{}\n\n",
-            str1, str2
-        );
+        println!("Entire Kernel String: {str1} \nKernel String:{str2}\n\n");
 
         let res = parse_kernel_version("Hello world".to_string());
         let (str1, str2) = res.unwrap();
-        println!(
-            "Entire Kernel String: {} \nKernel String:{}\n\n",
-            str1, str2
-        );
+        println!("Entire Kernel String: {str1} \nKernel String:{str2}\n\n");
 
         let res = parse_kernel_version("ã̸͙̪̖̮͖̘̼̯̱̙̮̩̝͐ḁ̶̛̘̼̥͙̰̂͆̋̓͗́͑́͛̔̏̉̈́͌̇̓͂͊̉̄̕̕͝͝ͅş̴̢͎͕̲̙̮̻̝͔̗̥̰̝͍̳͉̗̈́̅̋́ͅͅf̴̢̡̙͙̭̪̗̯͆̊̏̒͊͋̄̂͋́͌͂̃̆̽̂͛̓̌̽̒̒̐͂͘͘͘͝͝ą̷̭̬̪̀̆̇͋̂̒̅ď̵̢̢̧̛͓̜̦̻̻̜͈͎̼͇͈̖͔̼̫̻̗͉͍̻̟̙̇̉̈͐̀̈͜͜".to_string());
         let (str1, str2) = res.unwrap();
 
-        println!(
-            "Entire Kernel String: {} \nKernel String:{}\n\n",
-            str1, str2
-        );
+        println!("Entire Kernel String: {str1} \nKernel String:{str2}\n\n");
 
         let line = get_kernel_version().unwrap();
         let res = parse_kernel_version(line);
         let (str1, str2) = res.unwrap();
 
-        println!(
-            "Entire Kernel String: {} \nKernel String:{}\n\n",
-            str1, str2
-        );
+        println!("Entire Kernel String: {str1} \nKernel String:{str2}\n\n");
     }
 
     #[test]
@@ -584,7 +569,7 @@ mod test {
             }
         };
 
-        println!("table count: {:?}", table_count);
+        println!("table count: {table_count:?}");
 
         let max_conns = match get_lines(MAX_PATH) {
             Ok(a) => a,
@@ -599,7 +584,7 @@ mod test {
             }
         };
 
-        println!("Max conns: {:?}", max_conns);
+        println!("Max conns: {max_conns:?}");
 
         // Test read lines
         println!(

--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -46,7 +46,7 @@ impl dyn KernelInterface {
 
     pub fn iface_status(&self, iface: &str) -> Result<String, Error> {
         // cat so we can mock
-        let output = self.run_command("cat", &[&format!("/sys/class/net/{}/operstate", iface)])?;
+        let output = self.run_command("cat", &[&format!("/sys/class/net/{iface}/operstate")])?;
 
         let output = from_utf8(&output.stdout)?;
 
@@ -76,8 +76,7 @@ impl dyn KernelInterface {
                             }
                             None => {
                                 return Err(Error::RuntimeError(format!(
-                                "Cannot parse `wg show {} endpoints` output, got {}, captured {:?}",
-                                name, stdout, cap
+                                "Cannot parse `wg show {name} endpoints` output, got {stdout}, captured {cap:?}"
                             )))
                             }
                         }
@@ -87,8 +86,7 @@ impl dyn KernelInterface {
                 Ok(ip_str.parse()?)
             }
             None => Err(Error::RuntimeError(format!(
-                "Cannot parse `wg show {} endpoints` output, got {}, nothing captured",
-                name, stdout
+                "Cannot parse `wg show {name} endpoints` output, got {stdout}, nothing captured"
             ))),
         }
     }
@@ -177,7 +175,7 @@ impl dyn KernelInterface {
 
     /// Gets the mtu from an interface
     pub fn get_mtu(&self, if_name: &str) -> Result<usize, Error> {
-        let lines = get_lines(&format!("/sys/class/net/{}/mtu", if_name))?;
+        let lines = get_lines(&format!("/sys/class/net/{if_name}/mtu"))?;
         if let Some(mtu) = lines.get(0) {
             Ok(mtu.parse()?)
         } else {
@@ -187,7 +185,7 @@ impl dyn KernelInterface {
 
     /// Gets the ifindex from an interface
     pub fn get_ifindex(&self, if_name: &str) -> Result<usize, Error> {
-        let lines = get_lines(&format!("/sys/class/net/{}/ifindex", if_name))?;
+        let lines = get_lines(&format!("/sys/class/net/{if_name}/ifindex"))?;
         if let Some(ifindex) = lines.get(0) {
             Ok(ifindex.parse()?)
         } else {
@@ -198,7 +196,7 @@ impl dyn KernelInterface {
     /// Gets the iflink value from an interface. Physical interfaces have an ifindex and iflink that are
     /// identical but if you have a virtual (say DSA) interface then this will be the physical interface name
     pub fn get_iflink(&self, if_name: &str) -> Result<usize, Error> {
-        let lines = get_lines(&format!("/sys/class/net/{}/iflink", if_name))?;
+        let lines = get_lines(&format!("/sys/class/net/{if_name}/iflink"))?;
         if let Some(iflink) = lines.get(0) {
             Ok(iflink.parse()?)
         } else {

--- a/althea_kernel_interface/src/ip_addr.rs
+++ b/althea_kernel_interface/src/ip_addr.rs
@@ -26,7 +26,7 @@ impl dyn KernelInterface {
     pub fn add_ipv4(&self, ip: Ipv4Addr, dev: &str) -> Result<bool, Error> {
         // upwrap here because it's ok if we panic when the system does not have 'ip' installed
         let output = self
-            .run_command("ip", &["addr", "add", &format!("{}/32", ip), "dev", dev])
+            .run_command("ip", &["addr", "add", &format!("{ip}/32"), "dev", dev])
             .unwrap();
         // Get the first line, check if it has "file exists"
         match String::from_utf8(output.stderr) {
@@ -35,14 +35,13 @@ impl dyn KernelInterface {
                     if line.contains("File exists") {
                         Ok(false)
                     } else {
-                        Err(Error::RuntimeError(format!("Error setting ip {}", line)))
+                        Err(Error::RuntimeError(format!("Error setting ip {line}")))
                     }
                 }
                 None => Ok(true),
             },
             Err(e) => Err(Error::RuntimeError(format!(
-                "Could not decode stderr from ip with {:?}",
-                e
+                "Could not decode stderr from ip with {e:?}"
             ))),
         }
     }
@@ -102,10 +101,7 @@ impl dyn KernelInterface {
     pub fn add_ipv4_mask(&self, ip: Ipv4Addr, mask: u32, dev: &str) -> Result<bool, Error> {
         // upwrap here because it's ok if we panic when the system does not have 'ip' installed
         let output = self
-            .run_command(
-                "ip",
-                &["addr", "add", &format!("{}/{}", ip, mask), "dev", dev],
-            )
+            .run_command("ip", &["addr", "add", &format!("{ip}/{mask}"), "dev", dev])
             .unwrap();
         // Get the first line, check if it has "file exists"
         match String::from_utf8(output.stderr) {
@@ -114,14 +110,13 @@ impl dyn KernelInterface {
                     if line.contains("File exists") {
                         Ok(false)
                     } else {
-                        Err(Error::RuntimeError(format!("Error setting ip {}", line)))
+                        Err(Error::RuntimeError(format!("Error setting ip {line}")))
                     }
                 }
                 None => Ok(true),
             },
             Err(e) => Err(Error::RuntimeError(format!(
-                "Could not decode stderr from ip with {:?}",
-                e
+                "Could not decode stderr from ip with {e:?}"
             ))),
         }
     }

--- a/althea_kernel_interface/src/ip_neigh.rs
+++ b/althea_kernel_interface/src/ip_neigh.rs
@@ -23,10 +23,7 @@ impl dyn KernelInterface {
             }
             Err(e) => Err(Error::new(
                 ErrorKind::Other,
-                format!(
-                    "Unable to grab ip neigh from router. Failed with error {:?}",
-                    e
-                ),
+                format!("Unable to grab ip neigh from router. Failed with error {e:?}"),
             )),
         }
     }

--- a/althea_kernel_interface/src/ip_route.rs
+++ b/althea_kernel_interface/src/ip_route.rs
@@ -112,8 +112,7 @@ impl FromStr for IpRoute {
                     }))
                 } else {
                     Err(Error::InvalidRouteString(format!(
-                        "{} does not contain via, nic",
-                        s,
+                        "{s} does not contain via, nic",
                     )))
                 }
             } else {
@@ -143,8 +142,7 @@ impl FromStr for IpRoute {
                     }))
                 } else {
                     Err(Error::InvalidRouteString(format!(
-                        "{} does not contain nic",
-                        s,
+                        "{s} does not contain nic",
                     )))
                 }
             }
@@ -159,9 +157,9 @@ impl ToString for IpRoute {
         match self.clone() {
             IpRoute::DefaultRoute(DefaultRoute { via, nic, src, .. }) => {
                 if let Some(src) = src {
-                    format!("default via {} dev {} proto static src {}", via, nic, src)
+                    format!("default via {via} dev {nic} proto static src {src}")
                 } else {
-                    format!("default via {} dev {} proto static", via, nic)
+                    format!("default via {via} dev {nic} proto static")
                 }
             }
 
@@ -174,16 +172,16 @@ impl ToString for IpRoute {
                 ..
             }) => {
                 let mut out = if subnet == 32 {
-                    format!("{} ", dst)
+                    format!("{dst} ")
                 } else {
-                    format!("{}/{} ", dst, subnet)
+                    format!("{dst}/{subnet} ")
                 };
                 if let Some(via) = via {
-                    write!(out, "via {} ", via).unwrap();
+                    write!(out, "via {via} ").unwrap();
                 }
-                write!(out, "dev {} proto static ", nic).unwrap();
+                write!(out, "dev {nic} proto static ").unwrap();
                 if let Some(src) = src {
-                    write!(out, "src {} ", src).unwrap();
+                    write!(out, "src {src} ").unwrap();
                 }
                 out
             }

--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -94,12 +94,12 @@ pub enum KernelInterfaceError {
 impl fmt::Display for KernelInterfaceError {
     fn fmt(&self, f: &mut fmt::Formatter) -> FormatResult {
         match self {
-            KernelInterfaceError::RuntimeError(val) => write!(f, "Runtime Error: {}", val),
+            KernelInterfaceError::RuntimeError(val) => write!(f, "Runtime Error: {val}"),
             KernelInterfaceError::NoInterfaceError(val) => {
-                write!(f, "No interface by the name: {}", val)
+                write!(f, "No interface by the name: {val}")
             }
             KernelInterfaceError::AddressNotReadyError(val) => {
-                write!(f, "Address isn't ready yet: {}", val)
+                write!(f, "Address isn't ready yet: {val}")
             }
             KernelInterfaceError::WgExistsError => write!(f, "Wireguard Interface Already exists"),
             KernelInterfaceError::FailedToGetMemoryUsage => {
@@ -113,16 +113,16 @@ impl fmt::Display for KernelInterfaceError {
                 write!(f, "Could not pares /etc/opkg/customfeeds.conf")
             }
             KernelInterfaceError::TrafficControlError(val) => {
-                write!(f, "TrafficControl error {}", val)
+                write!(f, "TrafficControl error {val}")
             }
             KernelInterfaceError::EmptyRouteString => {
                 write!(f, "Can't parse an empty string into a route!")
             }
             KernelInterfaceError::InvalidRouteString(val) => {
-                write!(f, "InvalidRouteString {}", val)
+                write!(f, "InvalidRouteString {val}")
             }
             KernelInterfaceError::InvalidArchString(val) => {
-                write!(f, "InvalidArchString {}", val)
+                write!(f, "InvalidArchString {val}")
             }
             KernelInterfaceError::FailedToGetSystemTime => {
                 write!(f, "Failed to get system time!")
@@ -138,55 +138,55 @@ impl Error for KernelInterfaceError {}
 
 impl From<FromUtf8Error> for KernelInterfaceError {
     fn from(e: FromUtf8Error) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<IoError> for KernelInterfaceError {
     fn from(e: IoError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<AddrParseError> for KernelInterfaceError {
     fn from(e: AddrParseError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<ParseIntError> for KernelInterfaceError {
     fn from(e: ParseIntError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<ParseFloatError> for KernelInterfaceError {
     fn from(e: ParseFloatError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<AltheaTypesError> for KernelInterfaceError {
     fn from(e: AltheaTypesError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<Utf8Error> for KernelInterfaceError {
     fn from(e: Utf8Error) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<SystemTimeError> for KernelInterfaceError {
     fn from(e: SystemTimeError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 
 impl From<PingError> for KernelInterfaceError {
     fn from(e: PingError) -> Self {
-        KernelInterfaceError::RuntimeError(format!("{}", e))
+        KernelInterfaceError::RuntimeError(format!("{e}"))
     }
 }
 

--- a/althea_kernel_interface/src/manipulate_uci.rs
+++ b/althea_kernel_interface/src/manipulate_uci.rs
@@ -16,7 +16,7 @@ impl dyn KernelInterface {
 
     //Sets an arbitrary UCI variable on OpenWRT
     pub fn set_uci_var(&self, key: &str, value: &str) -> Result<(), KernelInterfaceError> {
-        self.run_uci("uci", &["set", &format!("{}={}", key, value)])?;
+        self.run_uci("uci", &["set", &format!("{key}={value}")])?;
         Ok(())
     }
 
@@ -82,7 +82,7 @@ impl dyn KernelInterface {
     }
 
     pub fn refresh_initd(&self, program: &str) -> Result<(), KernelInterfaceError> {
-        let output = self.run_command(&format!("/etc/init.d/{}", program), &["reload"])?;
+        let output = self.run_command(&format!("/etc/init.d/{program}"), &["reload"])?;
         if !output.status.success() {
             return Err(KernelInterfaceError::RuntimeError(format!(
                 "received error while refreshing {}: {}",

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -36,16 +36,16 @@ impl dyn KernelInterface {
         let links = String::from_utf8(self.run_command("ip", &["link"])?.stdout)?;
         let mut if_num = 0;
         //loop through the output of "ip links" until we find a wg suffix that isn't taken (e.g. "wg3")
-        while links.contains(format!("wg{}", if_num).as_str()) {
+        while links.contains(format!("wg{if_num}").as_str()) {
             if_num += 1;
         }
 
         let mut count = 0;
-        let mut interface = format!("wg{}", if_num);
+        let mut interface = format!("wg{if_num}");
         let mut res = self.setup_wg_if_named(&interface);
         while let Err(KernelInterfaceError::WgExistsError) = res {
             if_num += 1;
-            interface = format!("wg{}", if_num);
+            interface = format!("wg{if_num}");
             res = self.setup_wg_if_named(&interface);
             count += 1;
             if count > MAX_RETRY {
@@ -66,8 +66,7 @@ impl dyn KernelInterface {
                 return Err(KernelInterfaceError::WgExistsError);
             } else {
                 return Err(KernelInterfaceError::RuntimeError(format!(
-                    "received error adding wg link: {}",
-                    stderr
+                    "received error adding wg link: {stderr}"
                 )));
             }
         }
@@ -132,7 +131,7 @@ fn test_durations() {
     let d = UNIX_EPOCH + Duration::from_secs(5);
     let d2 = UNIX_EPOCH + Duration::from_secs(10);
 
-    println!("d: {:?}, d2: {:?}", d, d2);
+    println!("d: {d:?}, d2: {d2:?}");
 }
 
 #[test]

--- a/althea_kernel_interface/src/time.rs
+++ b/althea_kernel_interface/src/time.rs
@@ -8,7 +8,7 @@ impl dyn KernelInterface {
     /// Set the router's time using "date -s @seconds_since_unix_epoch"
     pub fn set_local_time(&self, time: SystemTime) -> Result<Output, Error> {
         let time_secs = time.duration_since(UNIX_EPOCH).unwrap().as_secs();
-        let t = format!("@{}", time_secs);
+        let t = format!("@{time_secs}");
         trace!("setting local time via 'date -s {}'", t);
         match self.run_command("date", &["-s", t.as_str()]) {
             Ok(output) => {

--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -19,8 +19,7 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to check qdisc for {}! {:?}",
-                iface_name, res
+                "Failed to check qdisc for {iface_name}! {res:?}"
             )));
         }
 
@@ -38,13 +37,12 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to check filter for {}! {:?}",
-                class_id, res
+                "Failed to check filter for {class_id}! {res:?}"
             )));
         }
 
         let stdout = &String::from_utf8(result.stdout)?;
-        Ok(stdout.contains(&format!("1:{}", class_id)))
+        Ok(stdout.contains(&format!("1:{class_id}")))
     }
 
     /// Gets the full flows list to pass to bulk functions
@@ -54,8 +52,7 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to get flows {:?}",
-                res
+                "Failed to get flows {res:?}"
             )));
         }
         Ok(String::from_utf8(result.stdout)?)
@@ -65,7 +62,7 @@ impl dyn KernelInterface {
     /// in the exit setup loop than running the same command several hundred times
     pub fn has_flow_bulk(&self, ip: Ipv4Addr, tc_out: &str) -> bool {
         let class_id = self.get_class_id(ip);
-        tc_out.contains(&format!("1:{}", class_id))
+        tc_out.contains(&format!("1:{class_id}"))
     }
 
     /// This function is the ipv6 version of has_flow_bulk, but is different in how its implemented. Since we simply cant
@@ -91,13 +88,12 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to check filter for {}! {:?}",
-                class_id, res
+                "Failed to check filter for {class_id}! {res:?}"
             )));
         }
 
         let stdout = &String::from_utf8(result.stdout)?;
-        Ok(stdout.contains(&format!("1:{}", class_id)))
+        Ok(stdout.contains(&format!("1:{class_id}")))
     }
 
     /// Determines if the provided interface has a configured qdisc
@@ -107,8 +103,7 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to check limit for {}! {:?}",
-                iface_name, res
+                "Failed to check limit for {iface_name}! {res:?}"
             )));
         }
 
@@ -126,8 +121,7 @@ impl dyn KernelInterface {
         if !result.status.success() {
             let res = String::from_utf8(result.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to check limit for {}! {:?}",
-                iface_name, res
+                "Failed to check limit for {iface_name}! {res:?}"
             )));
         }
 
@@ -155,7 +149,7 @@ impl dyn KernelInterface {
 
         match speed {
             Some(val) => {
-                mbit = format!("{}mbit", val);
+                mbit = format!("{val}mbit");
                 cake_args.extend(["bandwidth", &mbit])
             }
             None => cake_args.extend(["unlimited"]),
@@ -194,8 +188,7 @@ impl dyn KernelInterface {
                 let res = String::from_utf8(output.stderr)?;
                 error!("Cake and fallback fq_codel have both failed!");
                 return Err(Error::TrafficControlError(format!(
-                    "Failed to create new qdisc limit! {:?}",
-                    res
+                    "Failed to create new qdisc limit! {res:?}"
                 )));
             }
         }
@@ -229,11 +222,11 @@ impl dyn KernelInterface {
                 "1:",
                 "tbf",
                 "latency",
-                &format!("{}ms", latency),
+                &format!("{latency}ms"),
                 "burst",
-                &format!("{}", burst),
+                &format!("{burst}"),
                 "rate",
-                &format!("{}kbit", bw),
+                &format!("{bw}kbit"),
             ],
         )?;
 
@@ -242,8 +235,7 @@ impl dyn KernelInterface {
         } else {
             let res = String::from_utf8(output.stderr)?;
             Err(Error::TrafficControlError(format!(
-                "Failed to create new qdisc limit! {:?}",
-                res
+                "Failed to create new qdisc limit! {res:?}"
             )))
         }
     }
@@ -276,8 +268,7 @@ impl dyn KernelInterface {
         } else {
             let res = String::from_utf8(output.stderr)?;
             Err(Error::TrafficControlError(format!(
-                "Failed to create new qdisc limit! {:?}",
-                res
+                "Failed to create new qdisc limit! {res:?}"
             )))
         }
     }
@@ -297,7 +288,7 @@ impl dyn KernelInterface {
                             "parent",
                             "1:",
                             "classid",
-                            &format!("1:{}", class_id),
+                            &format!("1:{class_id}"),
                         ],
                     )?;
                 }
@@ -337,20 +328,19 @@ impl dyn KernelInterface {
                 "parent",
                 "1:",
                 "classid",
-                &format!("1:{}", class_id),
+                &format!("1:{class_id}"),
                 "htb",
                 "rate",
-                &format!("{}kbit", min_bw),
+                &format!("{min_bw}kbit"),
                 "ceil",
-                &format!("{}kbit", max_bw),
+                &format!("{max_bw}kbit"),
             ],
         )?;
 
         if !output.status.success() {
             let res = String::from_utf8(output.stderr)?;
             return Err(Error::TrafficControlError(format!(
-                "Failed to update qdisc class limit! {:?}",
-                res
+                "Failed to update qdisc class limit! {res:?}"
             )));
         }
 
@@ -399,7 +389,7 @@ impl dyn KernelInterface {
                 "dst",
                 &ip_net.to_string(),
                 "flowid",
-                &format!("1:{}", class_id),
+                &format!("1:{class_id}"),
             ],
         )?;
 
@@ -408,8 +398,7 @@ impl dyn KernelInterface {
         } else {
             let res = String::from_utf8(output.stderr)?;
             Err(Error::TrafficControlError(format!(
-                "Failed to create limit by ip! {:?}",
-                res
+                "Failed to create limit by ip! {res:?}"
             )))
         }
     }
@@ -435,9 +424,9 @@ impl dyn KernelInterface {
                 "match",
                 "ip",
                 "dst",
-                &format!("{}/32", ip),
+                &format!("{ip}/32"),
                 "flowid",
-                &format!("1:{}", class_id),
+                &format!("1:{class_id}"),
             ],
         )?;
 
@@ -446,8 +435,7 @@ impl dyn KernelInterface {
         } else {
             let res = String::from_utf8(output.stderr)?;
             Err(Error::TrafficControlError(format!(
-                "Failed to create limit by ip! {:?}",
-                res
+                "Failed to create limit by ip! {res:?}"
             )))
         }
     }

--- a/althea_types/src/error.rs
+++ b/althea_types/src/error.rs
@@ -11,7 +11,7 @@ pub enum AltheaTypesError {
 impl fmt::Display for AltheaTypesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> FormatResult {
         match self {
-            AltheaTypesError::WgParseError(val) => write!(f, "Failed to parse WgKey with {}", val),
+            AltheaTypesError::WgParseError(val) => write!(f, "Failed to parse WgKey with {val}"),
         }
     }
 }

--- a/althea_types/src/wifi_info.rs
+++ b/althea_types/src/wifi_info.rs
@@ -369,7 +369,7 @@ Survey data from wlan0
 
     let ret = extract_wifi_survey_data(str, "wlan0");
 
-    println!("{:?}", ret);
+    println!("{ret:?}");
 }
 
 #[test]
@@ -466,7 +466,7 @@ Station 54:88:0e:ab:fb:81 (on wlan1)
     current time:    1645656582646 ms";
 
     let ret = extract_wifi_station_data(str);
-    println!("{:?}", ret);
+    println!("{ret:?}");
 
     let old_str = "Station <mac removed> (on wlan1)
 	inactive time:	10 ms
@@ -496,7 +496,7 @@ Station 54:88:0e:ab:fb:81 (on wlan1)
 	connected time:	26651 seconds";
 
     let ret = extract_wifi_station_data(old_str);
-    println!("\n\n{:?}", ret);
+    println!("\n\n{ret:?}");
 }
 
 #[test]
@@ -518,5 +518,5 @@ fn test_extract_wifi_names() {
         }
     }
 
-    println!("{:?}", ret);
+    println!("{ret:?}");
 }

--- a/antenna_forwarding_client/src/error.rs
+++ b/antenna_forwarding_client/src/error.rs
@@ -34,8 +34,8 @@ impl Display for AntennaForwardingError {
             AntennaForwardingError::AntennaNotFound => write!(f, "Failed to find Antenna!",),
             AntennaForwardingError::IPNotSupported => write!(f, "Not supported!",),
             AntennaForwardingError::BlacklistedAddress => write!(f, "Blacklisted address!",),
-            AntennaForwardingError::KernelInterfaceError(e) => write!(f, "{}", e),
-            AntennaForwardingError::PingError(e) => write!(f, "{}", e),
+            AntennaForwardingError::KernelInterfaceError(e) => write!(f, "{e}"),
+            AntennaForwardingError::PingError(e) => write!(f, "{e}"),
         }
     }
 }

--- a/antenna_forwarding_protocol/src/error.rs
+++ b/antenna_forwarding_protocol/src/error.rs
@@ -39,7 +39,7 @@ impl Display for AntennaForwardingError {
                 write!(f, "Never found the end of the message",)
             }
             AntennaForwardingError::DoubleReadFailure { a, b } => {
-                write!(f, "Double read failure {:?} {:?}", a, b)
+                write!(f, "Double read failure {a:?} {b:?}")
             }
             AntennaForwardingError::ImpossibleError => write!(f, "Impossible error",),
             AntennaForwardingError::UnparsedBytesError {
@@ -48,11 +48,10 @@ impl Display for AntennaForwardingError {
             } => {
                 write!(
                     f,
-                    "Unparsed bytes! Messages {:#X?} Remaining bytes {:#X?}",
-                    messages, remaining_bytes
+                    "Unparsed bytes! Messages {messages:#X?} Remaining bytes {remaining_bytes:#X?}"
                 )
             }
-            AntennaForwardingError::MessageWriteError(e) => write!(f, "{}", e),
+            AntennaForwardingError::MessageWriteError(e) => write!(f, "{e}"),
         }
     }
 }

--- a/antenna_forwarding_protocol/src/lib.rs
+++ b/antenna_forwarding_protocol/src/lib.rs
@@ -73,15 +73,14 @@ impl Display for ForwardingProtocolError {
         match self {
             ForwardingProtocolError::SliceTooSmall { expected, actual } => write!(
                 f,
-                "SliceTooSmall expected {} bytes, got {} bytes",
-                expected, actual
+                "SliceTooSmall expected {expected} bytes, got {actual} bytes"
             ),
             ForwardingProtocolError::BadMagic => write!(f, "BadMagic"),
             ForwardingProtocolError::InvalidLen => write!(f, "InvalidLen"),
             ForwardingProtocolError::WrongPacketType => write!(f, "WrongPacketType"),
             ForwardingProtocolError::UnknownPacketType => write!(f, "UnknownPacketType"),
             ForwardingProtocolError::DecryptionFailed => write!(f, "DecryptionFailed"),
-            ForwardingProtocolError::SerdeError { message } => write!(f, "SerdeError {}", message),
+            ForwardingProtocolError::SerdeError { message } => write!(f, "SerdeError {message}"),
         }
     }
 }

--- a/auto_bridge/src/error.rs
+++ b/auto_bridge/src/error.rs
@@ -21,8 +21,8 @@ impl From<Web3Error> for TokenBridgeError {
 impl Display for TokenBridgeError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            TokenBridgeError::Web3Error(e) => write!(f, "{}", e),
-            TokenBridgeError::BadUniswapOutput(e) => write!(f, "{}", e),
+            TokenBridgeError::Web3Error(e) => write!(f, "{e}"),
+            TokenBridgeError::BadUniswapOutput(e) => write!(f, "{e}"),
             TokenBridgeError::HelperMessageNotReady => write!(
                 f,
                 "xDai validators are not finished preparing this withdraw",

--- a/auto_bridge/src/lib.rs
+++ b/auto_bridge/src/lib.rs
@@ -227,8 +227,7 @@ pub async fn get_relay_message_hash(
         Ok(a) => a,
         Err(e) => {
             return Err(TokenBridgeError::Web3Error(Web3Error::BadInput(format!(
-                "Error: {}",
-                e
+                "Error: {e}"
             ))))
         }
     };
@@ -241,8 +240,7 @@ pub async fn get_relay_message_hash(
         Ok(a) => a,
         Err(e) => {
             return Err(TokenBridgeError::Web3Error(Web3Error::BadInput(format!(
-                "Error: {}",
-                e
+                "Error: {e}"
             ))))
         }
     };
@@ -258,8 +256,7 @@ pub async fn get_relay_message_hash(
         Ok(a) => a,
         Err(e) => {
             return Err(TokenBridgeError::Web3Error(Web3Error::BadInput(format!(
-                "Error: {}",
-                e
+                "Error: {e}"
             ))))
         }
     };
@@ -337,7 +334,7 @@ pub async fn check_relayed_message(
 ) -> Result<bool, Web3Error> {
     let payload = match encode_call("relayedMessages(bytes32)", &[tx_hash.into()]) {
         Ok(a) => a,
-        Err(e) => return Err(Web3Error::BadInput(format!("Error: {}", e))),
+        Err(e) => return Err(Web3Error::BadInput(format!("Error: {e}"))),
     };
 
     let res = web3
@@ -729,7 +726,7 @@ mod tests {
             )
             .await
             .unwrap();
-            println!("{:?}", res);
+            println!("{res:?}");
         });
     }
 

--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -80,7 +80,7 @@ pub fn open_babel_stream(
     babel_port: u16,
     timeout: Duration,
 ) -> Result<TcpStream, BabelMonitorError> {
-    let socket_string = format!("[::1]:{}", babel_port);
+    let socket_string = format!("[::1]:{babel_port}");
     trace!("About to open Babel socket using {}", socket_string);
     let socket: SocketAddr = socket_string.parse().unwrap();
     let mut stream = TcpStream::connect_timeout(&socket, timeout)?;
@@ -129,7 +129,7 @@ fn read_babel(
 
     let output = String::from_utf8(buffer.to_vec());
     if let Err(e) = output {
-        return Err(BabelMonitorError::TcpError(format!("{:?}", e)));
+        return Err(BabelMonitorError::TcpError(format!("{e:?}")));
     }
     let output = output?;
     let output = output.trim_matches(char::from(0));
@@ -167,7 +167,7 @@ fn read_babel(
     } else if let Err(e) = babel_data {
         // some other error
         warn!("Babel read failed! {} {:?}", output, e);
-        return Err(BabelMonitorError::ReadFailed(format!("{:?}", e)));
+        return Err(BabelMonitorError::ReadFailed(format!("{e:?}")));
     }
     let babel_data = babel_data?;
 
@@ -176,7 +176,7 @@ fn read_babel(
 
 pub fn run_command(stream: &mut TcpStream, cmd: &str) -> Result<String, BabelMonitorError> {
     info!("Running babel command {}", cmd);
-    let cmd = format!("{}\n", cmd);
+    let cmd = format!("{cmd}\n");
     let bytes = cmd.as_bytes().to_vec();
     let out = stream.write_all(&bytes);
 
@@ -185,7 +185,7 @@ pub fn run_command(stream: &mut TcpStream, cmd: &str) -> Result<String, BabelMon
             info!("Command write succeeded, returning output");
             read_babel(stream, String::new(), 0)
         }
-        Err(e) => Err(BabelMonitorError::CommandFailed(cmd, format!("{:?}", e))),
+        Err(e) => Err(BabelMonitorError::CommandFailed(cmd, format!("{e:?}"))),
     }
 }
 
@@ -204,24 +204,21 @@ pub fn get_local_fee(stream: &mut TcpStream) -> Result<u32, BabelMonitorError> {
 }
 
 pub fn set_local_fee(stream: &mut TcpStream, new_fee: u32) -> Result<(), BabelMonitorError> {
-    let result = run_command(stream, &format!("fee {}", new_fee))?;
+    let result = run_command(stream, &format!("fee {new_fee}"))?;
 
     let _out = result;
     Ok(())
 }
 
 pub fn set_metric_factor(stream: &mut TcpStream, new_factor: u32) -> Result<(), BabelMonitorError> {
-    let result = run_command(stream, &format!("metric-factor {}", new_factor))?;
+    let result = run_command(stream, &format!("metric-factor {new_factor}"))?;
 
     let _out = result;
     Ok(())
 }
 
 pub fn monitor(stream: &mut TcpStream, iface: &str) -> Result<(), BabelMonitorError> {
-    let command = &format!(
-        "interface {} max-rtt-penalty 500 enable-timestamps true",
-        iface
-    );
+    let command = &format!("interface {iface} max-rtt-penalty 500 enable-timestamps true");
     let iface = iface.to_string();
     let result = run_command(stream, command)?;
 
@@ -247,7 +244,7 @@ pub fn redistribute_ip(
 }
 
 pub fn unmonitor(stream: &mut TcpStream, iface: &str) -> Result<(), BabelMonitorError> {
-    let command = format!("flush interface {}", iface);
+    let command = format!("flush interface {iface}");
     let iface = iface.to_string();
     let result = run_command(stream, &command)?;
 

--- a/babel_monitor/src/structs.rs
+++ b/babel_monitor/src/structs.rs
@@ -70,38 +70,36 @@ impl Display for BabelMonitorError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
             BabelMonitorError::VariableNotFound(a, b) => {
-                write!(f, "variable '{}' not found in '{}'", a, b,)
+                write!(f, "variable '{a}' not found in '{b}'",)
             }
-            BabelMonitorError::InvalidPreamble(a) => write!(f, "Invalid preamble: {}", a,),
+            BabelMonitorError::InvalidPreamble(a) => write!(f, "Invalid preamble: {a}",),
             BabelMonitorError::LocalFeeNotFound(a) => {
-                write!(f, "Could not find local fee in '{}'", a,)
+                write!(f, "Could not find local fee in '{a}'",)
             }
-            BabelMonitorError::CommandFailed(a, b) => write!(f, "Command '{}' failed. {}", a, b,),
-            BabelMonitorError::ReadFailed(a) => write!(f, "Erroneous Babel output:\n{}", a,),
+            BabelMonitorError::CommandFailed(a, b) => write!(f, "Command '{a}' failed. {b}",),
+            BabelMonitorError::ReadFailed(a) => write!(f, "Erroneous Babel output:\n{a}",),
             BabelMonitorError::NoTerminator(a) => {
-                write!(f, "No terminator after Babel output:\n{}", a,)
+                write!(f, "No terminator after Babel output:\n{a}",)
             }
             BabelMonitorError::NoNeighbor(a) => {
-                write!(f, "No Neighbor was found matching address:\n{}", a,)
+                write!(f, "No Neighbor was found matching address:\n{a}",)
             }
             BabelMonitorError::TcpError(a) => {
-                write!(f, "Tcp connection failure while talking to babel:\n{}", a,)
+                write!(f, "Tcp connection failure while talking to babel:\n{a}",)
             }
-            BabelMonitorError::BabelParseError(a) => write!(f, "Babel parsing failed:\n{}", a,),
-            BabelMonitorError::ReadFunctionError(e) => write!(f, "{}", e),
-            BabelMonitorError::BoolParseError(e) => write!(f, "{}", e),
-            BabelMonitorError::ParseAddrError(e) => write!(f, "{}", e),
-            BabelMonitorError::IntParseError(e) => write!(f, "{}", e),
-            BabelMonitorError::FloatParseError(e) => write!(f, "{}", e),
-            BabelMonitorError::NetworkError(e) => write!(f, "{}", e),
-            BabelMonitorError::NoRoute(a) => write!(f, "Route not found:\n{}", a,),
-            BabelMonitorError::TokioError(a) => write!(
-                f,
-                "Tokio had a failure while it was talking to babel:\n{}",
-                a,
-            ),
-            BabelMonitorError::MiscStringError(a) => write!(f, "{}", a,),
-            BabelMonitorError::FromUtf8Error(a) => write!(f, "{}", a,),
+            BabelMonitorError::BabelParseError(a) => write!(f, "Babel parsing failed:\n{a}",),
+            BabelMonitorError::ReadFunctionError(e) => write!(f, "{e}"),
+            BabelMonitorError::BoolParseError(e) => write!(f, "{e}"),
+            BabelMonitorError::ParseAddrError(e) => write!(f, "{e}"),
+            BabelMonitorError::IntParseError(e) => write!(f, "{e}"),
+            BabelMonitorError::FloatParseError(e) => write!(f, "{e}"),
+            BabelMonitorError::NetworkError(e) => write!(f, "{e}"),
+            BabelMonitorError::NoRoute(a) => write!(f, "Route not found:\n{a}",),
+            BabelMonitorError::TokioError(a) => {
+                write!(f, "Tokio had a failure while it was talking to babel:\n{a}",)
+            }
+            BabelMonitorError::MiscStringError(a) => write!(f, "{a}",),
+            BabelMonitorError::FromUtf8Error(a) => write!(f, "{a}",),
         }
     }
 }

--- a/clu/src/error.rs
+++ b/clu/src/error.rs
@@ -36,14 +36,14 @@ impl From<std::io::Error> for NewCluError {
 impl Display for NewCluError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            NewCluError::RuntimeError(a) => write!(f, "Runtime Error:\n{:?}", a,),
-            NewCluError::MeshError(e) => write!(f, "{}", e),
-            NewCluError::KernelInterfaceError(e) => write!(f, "{}", e),
-            NewCluError::StandardError(e) => write!(f, "{}", e),
+            NewCluError::RuntimeError(a) => write!(f, "Runtime Error:\n{a:?}",),
+            NewCluError::MeshError(e) => write!(f, "{e}"),
+            NewCluError::KernelInterfaceError(e) => write!(f, "{e}"),
+            NewCluError::StandardError(e) => write!(f, "{e}"),
             NewCluError::NoDeviceName(a) => {
-                write!(f, "Could not obtain device name from line {:?}", a,)
+                write!(f, "Could not obtain device name from line {a:?}",)
             }
-            NewCluError::ClarityError(e) => write!(f, "{}", e),
+            NewCluError::ClarityError(e) => write!(f, "{e}"),
         }
     }
 }

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -28,7 +28,7 @@ pub enum CluError {
 impl Display for CluError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            CluError::RuntimeError(a) => write!(f, "Runtime Error:\n{:?}", a,),
+            CluError::RuntimeError(a) => write!(f, "Runtime Error:\n{a:?}",),
         }
     }
 }
@@ -341,7 +341,7 @@ mod tests {
         let libsodium_secret: SecretKey = wg_gen_secret.into();
         let libsodium_pub = libsodium_secret.public_key();
         let libsodium_generated_public_key: WgKey = libsodium_pub.0.into();
-        println!("{} vs {}", wg_gen_pub, libsodium_generated_public_key);
+        println!("{wg_gen_pub} vs {libsodium_generated_public_key}");
         assert_eq!(libsodium_generated_public_key, wg_gen_pub);
     }
 }

--- a/rita_bin/build.rs
+++ b/rita_bin/build.rs
@@ -7,5 +7,5 @@ fn main() {
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .unwrap_or_else(|| "(unknown)".to_string());
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -73,7 +73,7 @@ fn main() {
     .unwrap_or_else(|e| e.exit());
 
     let settings_file = args.flag_config.clone();
-    println!("Settings file {}", settings_file);
+    println!("Settings file {settings_file}");
 
     // load the settings file, setup a thread to save it out every so often
     // and populate the memory cache of settings used throughout the program
@@ -93,7 +93,7 @@ fn main() {
 
         s.write(&settings_file).unwrap();
         settings::set_rita_client(s.clone());
-        println!("Look the client settings! {:?}", s);
+        println!("Look the client settings! {s:?}");
         s
     };
 
@@ -118,7 +118,7 @@ fn main() {
         let res =
             enable_remote_logging("rita".to_string(), log.dest_url, log.level, key.to_string());
 
-        println!("logging status {:?}", res);
+        println!("logging status {res:?}");
     }
 
     if cfg!(feature = "development") {

--- a/rita_bin/src/exit.rs
+++ b/rita_bin/src/exit.rs
@@ -106,7 +106,7 @@ fn main() {
         let settings = clu::exit_init("linux", settings);
         settings::set_rita_exit(settings.clone());
         sanity_check_config();
-        println!("Look the exit settings! {:?}", settings);
+        println!("Look the exit settings! {settings:?}");
         settings
     };
 
@@ -132,7 +132,7 @@ fn main() {
 
         let res =
             enable_remote_logging("rita_exit".to_string(), logging_url, level, key.to_string());
-        println!("logging status {:?}", res);
+        println!("logging status {res:?}");
     }
 
     if cfg!(feature = "development") {

--- a/rita_client/src/dashboard/auth.rs
+++ b/rita_client/src/dashboard/auth.rs
@@ -30,12 +30,12 @@ pub async fn set_pass(router_pass: Json<RouterPassword>) -> HttpResponse {
 
     if KI.is_openwrt() {
         if let Err(e) = KI.set_system_password(router_pass.password) {
-            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));
+            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e}"));
         }
 
         // We edited disk contents, force global sync
         if let Err(e) = KI.fs_sync() {
-            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));
+            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e}"));
         }
     }
 

--- a/rita_client/src/dashboard/devices_on_lan.rs
+++ b/rita_client/src/dashboard/devices_on_lan.rs
@@ -220,8 +220,7 @@ pub async fn get_devices_lan_endpoint(_req: HttpRequest) -> HttpResponse {
                 Ok(info) => info,
                 Err(e) => {
                     return HttpResponse::InternalServerError().json(format!(
-                        "Unable to grab rita client hardware information. Failed with error {:?}",
-                        e
+                        "Unable to grab rita client hardware information. Failed with error {e:?}"
                     ));
                 }
             };

--- a/rita_client/src/dashboard/eth_private_key.rs
+++ b/rita_client/src/dashboard/eth_private_key.rs
@@ -13,7 +13,7 @@ pub async fn get_eth_private_key(_req: HttpRequest) -> HttpResponse {
 
     match settings::get_rita_client().payment.eth_private_key {
         Some(pk) => {
-            ret.insert("eth_private_key".to_owned(), format!("{:x}", pk));
+            ret.insert("eth_private_key".to_owned(), format!("{pk:x}"));
         }
         None => {
             let error_msg = "No eth key configured yet";

--- a/rita_client/src/dashboard/exits.rs
+++ b/rita_client/src/dashboard/exits.rs
@@ -101,10 +101,10 @@ pub fn dashboard_get_exit_info() -> Result<Vec<ExitInfo>, RitaClientError> {
                     Ok(output)
                 }
 
-                Err(e) => Err(RitaClientError::MiscStringError(format!("{}", e))),
+                Err(e) => Err(RitaClientError::MiscStringError(format!("{e}"))),
             }
         }
-        Err(e) => Err(RitaClientError::MiscStringError(format!("{}", e))),
+        Err(e) => Err(RitaClientError::MiscStringError(format!("{e}"))),
     }
 }
 
@@ -141,7 +141,7 @@ pub async fn get_exit_info(_req: HttpRequest) -> HttpResponse {
     debug!("Exit endpoint hit!");
     match dashboard_get_exit_info() {
         Ok(a) => HttpResponse::Ok().json(a),
-        Err(e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{:?}", e)),
+        Err(e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e:?}")),
     }
 }
 
@@ -174,7 +174,7 @@ pub async fn reset_exit(path: Path<String>) -> HttpResponse {
         error!("Requested a reset on unknown exit {:?}", exit_name);
         ret.insert(
             "error".to_owned(),
-            format!("Requested reset on unknown exit {:?}", exit_name),
+            format!("Requested reset on unknown exit {exit_name:?}"),
         );
 
         HttpResponse::build(StatusCode::BAD_REQUEST).json(ret)
@@ -206,7 +206,7 @@ pub async fn select_exit(path: Path<String>) -> HttpResponse {
         error!("Requested selection of an unknown exit {:?}", exit_name);
         ret.insert(
             "error".to_owned(),
-            format!("Requested selection of an unknown exit {:?}", exit_name),
+            format!("Requested selection of an unknown exit {exit_name:?}"),
         );
         HttpResponse::build(StatusCode::BAD_REQUEST).json(ret)
     }
@@ -222,7 +222,7 @@ pub async fn register_to_exit(path: Path<String>) -> HttpResponse {
     if let Err(e) = exit_setup_request(exit_name, None).await {
         error!("exit_setup_request() failed with: {:?}", e);
         ret.insert("error".to_owned(), "Exit setup request failed".to_owned());
-        ret.insert("rust_error".to_owned(), format!("{:?}", e));
+        ret.insert("rust_error".to_owned(), format!("{e:?}"));
         return HttpResponse::build(StatusCode::BAD_REQUEST).json(ret);
     }
     HttpResponse::Ok().json(ret)
@@ -236,7 +236,7 @@ pub async fn verify_on_exit_with_code(path: Path<(String, String)>) -> HttpRespo
     if let Err(e) = exit_setup_request(exit_name, Some(code)).await {
         error!("exit_setup_request() failed with: {:?}", e);
         ret.insert("error".to_owned(), "Exit setup request failed".to_owned());
-        ret.insert("rust_error".to_owned(), format!("{:?}", e));
+        ret.insert("rust_error".to_owned(), format!("{e:?}"));
         return HttpResponse::build(StatusCode::BAD_REQUEST).json(ret);
     }
     HttpResponse::Ok().json(ret)

--- a/rita_client/src/dashboard/interfaces.rs
+++ b/rita_client/src/dashboard/interfaces.rs
@@ -102,7 +102,7 @@ pub fn ethernet2mode(ifname: &str, setting_name: &str) -> Result<InterfaceMode, 
             let prefix = "network.backhaul";
             let backhaul = KI.uci_show(Some(prefix))?;
             trace!("{:?}", backhaul);
-            let proto = if let Some(val) = backhaul.get(&format!("{}.proto", prefix)) {
+            let proto = if let Some(val) = backhaul.get(&format!("{prefix}.proto")) {
                 val
             } else {
                 return Err(RitaClientError::InterfaceModeError(
@@ -114,9 +114,9 @@ pub fn ethernet2mode(ifname: &str, setting_name: &str) -> Result<InterfaceMode, 
                 return Ok(InterfaceMode::Wan);
             } else if proto.contains("static") {
                 let opt_tuple = (
-                    backhaul.get(&format!("{}.netmask", prefix)),
-                    backhaul.get(&format!("{}.ipaddr", prefix)),
-                    backhaul.get(&format!("{}.gateway", prefix)),
+                    backhaul.get(&format!("{prefix}.netmask")),
+                    backhaul.get(&format!("{prefix}.ipaddr")),
+                    backhaul.get(&format!("{prefix}.gateway")),
                 );
                 if let (Some(netmask), Some(ipaddr), Some(gateway)) = opt_tuple {
                     return Ok(InterfaceMode::StaticWan {
@@ -302,11 +302,11 @@ pub fn ethernet_transform_mode(
             return_codes.push(ret);
             let ret = KI.set_uci_var("network.backhaul.proto", "static");
             return_codes.push(ret);
-            let ret = KI.set_uci_var("network.backhaul.netmask", &format!("{}", netmask));
+            let ret = KI.set_uci_var("network.backhaul.netmask", &format!("{netmask}"));
             return_codes.push(ret);
-            let ret = KI.set_uci_var("network.backhaul.ipaddr", &format!("{}", ipaddr));
+            let ret = KI.set_uci_var("network.backhaul.ipaddr", &format!("{ipaddr}"));
             return_codes.push(ret);
-            let ret = KI.set_uci_var("network.backhaul.gateway", &format!("{}", gateway));
+            let ret = KI.set_uci_var("network.backhaul.gateway", &format!("{gateway}"));
             return_codes.push(ret);
         }
         InterfaceMode::LTE => {
@@ -346,9 +346,9 @@ pub fn ethernet_transform_mode(
 
             let ret = KI.set_uci_var(&filtered_ifname, "interface");
             return_codes.push(ret);
-            let ret = KI.set_uci_var(&format!("{}.ifname", filtered_ifname), ifname);
+            let ret = KI.set_uci_var(&format!("{filtered_ifname}.ifname"), ifname);
             return_codes.push(ret);
-            let ret = KI.set_uci_var(&format!("{}.proto", filtered_ifname), "static");
+            let ret = KI.set_uci_var(&format!("{filtered_ifname}.proto"), "static");
             return_codes.push(ret);
         }
         InterfaceMode::Unknown => unimplemented!(),
@@ -541,7 +541,7 @@ pub async fn wlan_lightclient_set(enabled: Path<bool>) -> HttpResponse {
 /// A helper function for adding entries to a list
 pub fn list_add(list: &str, entry: &str) -> String {
     if !list.is_empty() {
-        format!("{} {}", list, entry)
+        format!("{list} {entry}")
     } else {
         entry.to_string()
     }
@@ -562,7 +562,7 @@ pub fn list_remove(list: &str, entry: &str) -> String {
                     new_list = tmp_list + filtered_item;
                     first = false;
                 } else {
-                    new_list = tmp_list + &format!(" {}", filtered_item);
+                    new_list = tmp_list + &format!(" {filtered_item}");
                 }
             }
         }
@@ -632,7 +632,7 @@ pub async fn get_interfaces_endpoint(_req: HttpRequest) -> HttpResponse {
         Ok(val) => HttpResponse::Ok().json(val),
         Err(e) => {
             error!("get_interfaces failed with {:?}", e);
-            HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{:?}", e))
+            HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e:?}"))
         }
     }
 }

--- a/rita_client/src/dashboard/localization.rs
+++ b/rita_client/src/dashboard/localization.rs
@@ -81,7 +81,7 @@ pub async fn get_wyre_reservation(amount: Json<AmountRequest>) -> HttpResponse {
     let mut response = match response {
         Ok(a) => a,
         Err(e) => {
-            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));
+            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e}"));
         }
     };
 

--- a/rita_client/src/dashboard/logging.rs
+++ b/rita_client/src/dashboard/logging.rs
@@ -22,12 +22,12 @@ pub async fn remote_logging(path: Path<bool>) -> HttpResponse {
 
     if let Err(e) = settings::write_config() {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Failed to write config {:?}", e));
+            .json(format!("Failed to write config {e:?}"));
     }
 
     if let Err(e) = KI.run_command(service_path.as_str(), &["restart"]) {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Failed to restart service {:?}", e));
+            .json(format!("Failed to restart service {e:?}"));
     }
 
     HttpResponse::Ok().json(())
@@ -47,7 +47,7 @@ pub async fn remote_logging_level(path: Path<String>) -> HttpResponse {
         Ok(level) => level,
         Err(e) => {
             return HttpResponse::build(StatusCode::BAD_REQUEST)
-                .json(format!("Could not parse loglevel {:?}", e));
+                .json(format!("Could not parse loglevel {e:?}"));
         }
     };
 
@@ -61,12 +61,12 @@ pub async fn remote_logging_level(path: Path<String>) -> HttpResponse {
 
     if let Err(e) = settings::write_config() {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Failed to write config {:?}", e));
+            .json(format!("Failed to write config {e:?}"));
     }
 
     if let Err(e) = KI.run_command(service_path.as_str(), &["restart"]) {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Failed to restart service {:?}", e));
+            .json(format!("Failed to restart service {e:?}"));
     }
 
     HttpResponse::Ok().json(())

--- a/rita_client/src/dashboard/mesh_ip.rs
+++ b/rita_client/src/dashboard/mesh_ip.rs
@@ -8,7 +8,7 @@ pub async fn get_mesh_ip(_req: HttpRequest) -> HttpResponse {
 
     match settings::get_rita_client().network.mesh_ip {
         Some(ip) => {
-            ret.insert("mesh_ip".to_owned(), format!("{}", ip));
+            ret.insert("mesh_ip".to_owned(), format!("{ip}"));
         }
         None => {
             let error_msg = "No mesh IP configured yet";

--- a/rita_client/src/dashboard/mod.rs
+++ b/rita_client/src/dashboard/mod.rs
@@ -208,7 +208,7 @@ pub fn start_client_dashboard(rita_dashboard_port: u16) {
                     .route("/email", web::post().to(set_email))
             })
             .workers(1)
-            .bind(format!("[::0]:{}", rita_dashboard_port))
+            .bind(format!("[::0]:{rita_dashboard_port}"))
             .unwrap()
             .shutdown_timeout(0)
             .run()

--- a/rita_client/src/dashboard/neighbors.rs
+++ b/rita_client/src/dashboard/neighbors.rs
@@ -41,10 +41,10 @@ pub async fn get_routes(_req: HttpRequest) -> HttpResponse {
         Ok(mut stream) => match parse_routes(&mut stream) {
             Ok(routes) => HttpResponse::Ok().json(routes),
             Err(e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                .json(format!("Unable to parse babel routes: {}", e)),
+                .json(format!("Unable to parse babel routes: {e}")),
         },
         Err(e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Unable to open babel stream to get routes: {}", e)),
+            .json(format!("Unable to open babel stream to get routes: {e}")),
     }
 }
 

--- a/rita_client/src/dashboard/prices.rs
+++ b/rita_client/src/dashboard/prices.rs
@@ -24,7 +24,7 @@ pub async fn set_auto_pricing(path: Path<bool>) -> HttpResponse {
     // try and save the config and fail if we can't
     if let Err(e) = settings::write_config() {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Error writing config: {}", e));
+            .json(format!("Error writing config: {e}"));
     }
 
     HttpResponse::Ok().json(())

--- a/rita_client/src/dashboard/remote_access.rs
+++ b/rita_client/src/dashboard/remote_access.rs
@@ -18,7 +18,7 @@ pub async fn get_remote_access_status(_req: HttpRequest) -> HttpResponse {
     HttpResponse::Ok().json(match check_dropbear_config() {
         Ok(a) => a,
         Err(e) => {
-            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));
+            return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e}"));
         }
     })
 }
@@ -62,7 +62,7 @@ fn check_dropbear_config() -> Result<bool, RitaClientError> {
 pub async fn set_remote_access_status(path: Path<bool>) -> HttpResponse {
     let remote_access = path.into_inner();
     if let Err(e) = set_remote_access_internal(remote_access) {
-        return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{}", e));
+        return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!("{e}"));
     }
     HttpResponse::Ok().json(())
 }

--- a/rita_client/src/dashboard/router.rs
+++ b/rita_client/src/dashboard/router.rs
@@ -13,7 +13,7 @@ pub async fn reboot_router(_req: HttpRequest) -> HttpResponse {
     if KI.is_openwrt() {
         if let Err(e) = KI.run_command("reboot", &[]) {
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                .json(format!("Cannot run reboot: {}", e));
+                .json(format!("Cannot run reboot: {e}"));
         }
         HttpResponse::Ok().json(())
     } else {
@@ -31,8 +31,7 @@ pub async fn update_router(_req: HttpRequest) -> HttpResponse {
             return HttpResponse::Ok().json("No update instructions set, doing nothing");
         }
         if let Err(e) = update_system(reader.as_ref().unwrap().clone()) {
-            return HttpResponse::Ok()
-                .json(format!("Retrieved Error while performing update {}", e));
+            return HttpResponse::Ok().json(format!("Retrieved Error while performing update {e}"));
         }
         HttpResponse::Ok().json(())
     } else {

--- a/rita_client/src/dashboard/system_chain.rs
+++ b/rita_client/src/dashboard/system_chain.rs
@@ -11,7 +11,7 @@ pub async fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse 
     let id: Result<SystemChain, ()> = path.into_inner().parse();
     if id.is_err() {
         return HttpResponse::build(StatusCode::BAD_REQUEST)
-            .json(format!("Could not parse {:?} into a SystemChain enum!", id));
+            .json(format!("Could not parse {id:?} into a SystemChain enum!"));
     }
     let id = id.unwrap();
 
@@ -23,7 +23,7 @@ pub async fn set_system_blockchain_endpoint(path: Path<String>) -> HttpResponse 
 
     if let Err(e) = settings::write_config() {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Error while writing config: {:?}", e));
+            .json(format!("Error while writing config: {e:?}"));
     }
 
     HttpResponse::Ok().json(())

--- a/rita_client/src/error.rs
+++ b/rita_client/src/error.rs
@@ -112,37 +112,36 @@ impl From<std::io::Error> for RitaClientError {
 impl Display for RitaClientError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            RitaClientError::InterfaceModeError(a) => write!(f, "{}", a,),
+            RitaClientError::InterfaceModeError(a) => write!(f, "{a}",),
             RitaClientError::InterfaceToggleError {
                 main_error,
                 revert_status,
             } => {
                 write!(
                     f,
-                    "Error running UCI commands! {:?} \nRevert attempted: {:?}",
-                    main_error, revert_status
+                    "Error running UCI commands! {main_error:?} \nRevert attempted: {revert_status:?}"
                 )
             }
-            RitaClientError::AddrParseError(a) => write!(f, "{}", a,),
-            RitaClientError::MiscStringError(e) => write!(f, "{}", e),
-            RitaClientError::ValidationError(e) => write!(f, "{}", e),
+            RitaClientError::AddrParseError(a) => write!(f, "{a}",),
+            RitaClientError::MiscStringError(e) => write!(f, "{e}"),
+            RitaClientError::ValidationError(e) => write!(f, "{e}"),
             RitaClientError::SendRequestError(e) => {
-                write!(f, "Error with get request for exit info: {}", e)
+                write!(f, "Error with get request for exit info: {e}")
             }
-            RitaClientError::JsonPayloadError(e) => write!(f, "{}", e),
-            RitaClientError::OldJsonPayloadError(e) => write!(f, "{}", e),
-            RitaClientError::SerdeJsonError(e) => write!(f, "{}", e),
-            RitaClientError::FromUtf8Error(e) => write!(f, "{}", e),
+            RitaClientError::JsonPayloadError(e) => write!(f, "{e}"),
+            RitaClientError::OldJsonPayloadError(e) => write!(f, "{e}"),
+            RitaClientError::SerdeJsonError(e) => write!(f, "{e}"),
+            RitaClientError::FromUtf8Error(e) => write!(f, "{e}"),
             RitaClientError::TimeoutError(e) => {
-                write!(f, "Error with post request for exit status: {}", e)
+                write!(f, "Error with post request for exit status: {e}")
             }
-            RitaClientError::NoExitError(e) => write!(f, "No valid exit for {}", e),
-            RitaClientError::ExitNotFound(e) => write!(f, "Could not find exit {:?}", e),
+            RitaClientError::NoExitError(e) => write!(f, "No valid exit for {e}"),
+            RitaClientError::ExitNotFound(e) => write!(f, "Could not find exit {e:?}"),
             RitaClientError::NoExitIPError(e) => {
-                write!(f, "Found exitServer: {:?}, but no exit ip", e)
+                write!(f, "Found exitServer: {e:?}, but no exit ip")
             }
-            RitaClientError::RitaCommonError(e) => write!(f, "{}", e),
-            RitaClientError::ParseIntError(e) => write!(f, "{}", e),
+            RitaClientError::RitaCommonError(e) => write!(f, "{e}"),
+            RitaClientError::ParseIntError(e) => write!(f, "{e}"),
         }
     }
 }

--- a/rita_client/src/exit_manager/time_sync.rs
+++ b/rita_client/src/exit_manager/time_sync.rs
@@ -17,7 +17,7 @@ pub async fn get_exit_time(exit: ExitServer, exit_name: String) -> Option<System
     info!("Getting the exit time");
     let exit_ip = get_selected_exit_ip(exit_name).expect("There should be an exit ip here");
     let exit_port = exit.registration_port;
-    let url = format!("http://[{}]:{}/time", exit_ip, exit_port);
+    let url = format!("http://[{exit_ip}]:{exit_port}/time");
 
     let client = awc::Client::default();
     let response = match client.get(&url).send().await {

--- a/rita_client/src/heartbeat/mod.rs
+++ b/rita_client/src/heartbeat/mod.rs
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn check_resolver() {
         let heartbeat_url = "dai.althea.net:33333";
-        println!("heartbeat url set to {}", heartbeat_url);
+        println!("heartbeat url set to {heartbeat_url}");
         //let mut length = false;
         let dns_request = heartbeat_url.to_socket_addrs();
         println!("dns_req set");
@@ -407,6 +407,6 @@ mod tests {
                 false
             }
         };
-        println!("{}", res)
+        println!("{res}")
     }
 }

--- a/rita_client/src/lib.rs
+++ b/rita_client/src/lib.rs
@@ -67,14 +67,13 @@ impl Default for Args {
 /// and does not need to be specified.
 pub fn get_client_usage(version: &str, git_hash: &str) -> String {
     format!(
-        "Usage: {} [--config=<settings>] [--platform=<platform>] [--future]
+        "Usage: {APP_NAME} [--config=<settings>] [--platform=<platform>] [--future]
 Options:
     -c, --config=<settings>     Name of config file
     -p, --platform=<platform>   Platform (linux or OpenWrt)
     --future                    Enable B side of A/B releases
 About:
-    Version {} - {}
-    git hash {}",
-        APP_NAME, READABLE_VERSION, version, git_hash
+    Version {READABLE_VERSION} - {version}
+    git hash {git_hash}"
     )
 }

--- a/rita_client/src/logging.rs
+++ b/rita_client/src/logging.rs
@@ -48,9 +48,6 @@ pub fn enable_remote_logging() -> Result<(), RitaClientError> {
     }
     log::set_max_level(level);
 
-    println!(
-        "Remote compressed logging enabled with target {}",
-        logging_url
-    );
+    println!("Remote compressed logging enabled with target {logging_url}");
     Ok(())
 }

--- a/rita_client/src/operator_update/mod.rs
+++ b/rita_client/src/operator_update/mod.rs
@@ -638,7 +638,7 @@ mod tests {
             .truncate(true)
             .open(file_name);
         let operator_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL+UBakquB9rJ7tA2H+U43H/xNmpJiHpOkHGpVfFUXgP OPERATOR";
-        writeln!(test_file.unwrap(), "{}", operator_key).expect("setup failed to create temp file");
+        writeln!(test_file.unwrap(), "{operator_key}").expect("setup failed to create temp file");
         operator_key
     }
     fn remove_temp_file(file_name: &str) -> Result<(), Error> {

--- a/rita_client/src/operator_update/updater.rs
+++ b/rita_client/src/operator_update/updater.rs
@@ -21,7 +21,7 @@ pub fn update_system(instruction: UpdateType) -> Result<(), KernelInterfaceError
                         Ok(o) => match o.status.code() {
                             Some(0) => info!("opkg completed successfully! {:?}", o),
                             Some(_) => {
-                                let err = format!("opkg has failed! {:?}", o);
+                                let err = format!("opkg has failed! {o:?}");
                                 error!("{}", err);
                             }
                             None => warn!("No return code form opkg update? {:?}", o),

--- a/rita_client/src/traffic_watcher/mod.rs
+++ b/rita_client/src/traffic_watcher/mod.rs
@@ -103,7 +103,7 @@ pub async fn query_exit_debts(msg: QueryExitDebts) {
     // a domain name, so in order to do peer to peer requests we use with_connection and our own
     // socket specification
     let our_id = settings::get_rita_client().get_identity();
-    let request = format!("http://{}:{}/client_debt", exit_addr, exit_port);
+    let request = format!("http://{exit_addr}:{exit_port}/client_debt");
     // it's an ipaddr appended to a u16, there's no real way for this to fail
     // unless of course it's an ipv6 address and you don't do the []
 

--- a/rita_common/src/dashboard/babel.rs
+++ b/rita_common/src/dashboard/babel.rs
@@ -45,7 +45,7 @@ pub async fn set_local_fee(path: Path<u32>) -> HttpResponse {
                     // try and save the config and fail if we can't
                     if let Err(e) = settings::write_config() {
                         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                            .json(format!("{:?}", e));
+                            .json(format!("{e:?}"));
                     }
                     HttpResponse::Ok().json(())
                 }
@@ -82,7 +82,7 @@ pub async fn set_metric_factor(path: Path<u32>) -> HttpResponse {
                     // try and save the config and fail if we can't
                     if let Err(e) = settings::write_config() {
                         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                            .json(format!("{}", e));
+                            .json(format!("{e}"));
                     }
 
                     HttpResponse::Ok().json(())

--- a/rita_common/src/dashboard/settings.rs
+++ b/rita_common/src/dashboard/settings.rs
@@ -5,7 +5,7 @@ pub async fn get_settings(_req: HttpRequest) -> HttpResponse {
     match settings::get_config_json() {
         Ok(a) => HttpResponse::Ok().json(a),
         Err(e) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Unable to get config: {}", e)),
+            .json(format!("Unable to get config: {e}")),
     }
 }
 
@@ -13,7 +13,7 @@ pub async fn set_settings(new_settings: Json<serde_json::Value>) -> HttpResponse
     debug!("Set settings endpoint hit!");
     if let Err(e) = settings::merge_config_json(new_settings.into_inner()) {
         return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-            .json(format!("Unable to set settings: {}", e));
+            .json(format!("Unable to set settings: {e}"));
     }
 
     HttpResponse::Ok().finish()

--- a/rita_common/src/dashboard/wallet.rs
+++ b/rita_common/src/dashboard/wallet.rs
@@ -77,8 +77,7 @@ fn withdraw_handler(address: Address, amount: Option<Uint256>) -> HttpResponse {
         (SystemChain::Xdai, SystemChain::Xdai) => queue_eth_compatible_withdraw(address, amount),
         (SystemChain::Xdai, SystemChain::Ethereum) => xdai_to_eth_withdraw(address, amount),
         (_, _) => HttpResponse::build(StatusCode::from_u16(500u16).unwrap()).json(format!(
-            "System chain is {} but withdraw chain is {}, withdraw impossible!",
-            system_chain, withdraw_chain
+            "System chain is {system_chain} but withdraw chain is {withdraw_chain}, withdraw impossible!"
         )),
     }
 }
@@ -151,8 +150,6 @@ fn xdai_to_eth_withdraw(address: Address, amount: Uint256) -> HttpResponse {
         amount,
     }) {
         Ok(_) => HttpResponse::Ok().json("View endpoints for progress"),
-        Err(e) => {
-            HttpResponse::build(StatusCode::from_u16(500u16).unwrap()).json(format!("{:?}", e))
-        }
+        Err(e) => HttpResponse::build(StatusCode::from_u16(500u16).unwrap()).json(format!("{e:?}")),
     }
 }

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -1302,16 +1302,16 @@ mod tests {
         let serialized = bincode::serialize(&debt_data_to_ser(debt_data.clone())).unwrap();
         let mut file = File::create(file_path).expect("Why fail");
         if let Err(e) = file.write_all(&serialized) {
-            println!("{:?}", e);
+            println!("{e:?}");
         }
 
         match deserialize_from_binary(file_path.to_string()) {
-            Some(a) => println!("{:?}", a),
+            Some(a) => println!("{a:?}"),
             None => print!("Unable to deserial"),
         }
 
         if let Err(e) = remove_file(file_path) {
-            println!("Remove the file: {:?}", e);
+            println!("Remove the file: {e:?}");
         }
 
         // TEST USING BufReader / BufWriter

--- a/rita_common/src/error.rs
+++ b/rita_common/src/error.rs
@@ -76,31 +76,31 @@ impl Display for RitaCommonError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
             RitaCommonError::ConversionError(a) => write!(
-                f, "Conversion Error: {}", a,
+                f, "Conversion Error: {a}",
             ),
-            RitaCommonError::LoggerError(e) => write!(f, "{}", e),
-            RitaCommonError::SetLoggerError(e) => write!(f, "{}", e),
-            RitaCommonError::UCIError(a) => write!(f, "{}", a,),
+            RitaCommonError::LoggerError(e) => write!(f, "{e}"),
+            RitaCommonError::SetLoggerError(e) => write!(f, "{e}"),
+            RitaCommonError::UCIError(a) => write!(f, "{a}",),
             RitaCommonError::ToggleError(a) => write!(
-                f, "Toggle Error: {}", a,
+                f, "Toggle Error: {a}",
             ),
             RitaCommonError::NicknameError(a) => write!(
-                f, "Nickname Error: {}", a,
+                f, "Nickname Error: {a}",
             ),
-            RitaCommonError::SettingsError(a) => write!(f, "{}", a,),
+            RitaCommonError::SettingsError(a) => write!(f, "{a}",),
             RitaCommonError::CapacityError(a) => write!(
-                f, "Capacity Error: {}", a,
+                f, "Capacity Error: {a}",
             ),
-            RitaCommonError::MiscStringError(a) => write!(f, "{}", a,),
-            RitaCommonError::KernelInterfaceError(a) => write!(f, "{}", a,),
-            RitaCommonError::StdError(a) => write!(f, "{}", a,),
+            RitaCommonError::MiscStringError(a) => write!(f, "{a}",),
+            RitaCommonError::KernelInterfaceError(a) => write!(f, "{a}",),
+            RitaCommonError::StdError(a) => write!(f, "{a}",),
             RitaCommonError::Lowest20Error(a) => write!(
-                f, "There is no entry at index {}, should not reach this condition, error with GAS_PRICES vecDeque logic", a,
+                f, "There is no entry at index {a}, should not reach this condition, error with GAS_PRICES vecDeque logic",
             ),
-            RitaCommonError::BabelMonitorError(a) => write!(f, "{}", a,),
-            RitaCommonError::SysTimeError(a) => write!(f, "{}", a,),
-            RitaCommonError::OldSendRequestError(e) => write!(f, "{}", e),
-            RitaCommonError::BincodeError(e) => write!(f, "{}", e),
+            RitaCommonError::BabelMonitorError(a) => write!(f, "{a}",),
+            RitaCommonError::SysTimeError(a) => write!(f, "{a}",),
+            RitaCommonError::OldSendRequestError(e) => write!(f, "{e}"),
+            RitaCommonError::BincodeError(e) => write!(f, "{e}"),
 
         }
     }

--- a/rita_common/src/logging.rs
+++ b/rita_common/src/logging.rs
@@ -46,6 +46,6 @@ pub fn enable_remote_logging(
     }
     log::set_max_level(level);
 
-    println!("Remote compressed logging enabled with target {}", log_url);
+    println!("Remote compressed logging enabled with target {log_url}");
     Ok(())
 }

--- a/rita_common/src/middleware.rs
+++ b/rita_common/src/middleware.rs
@@ -92,7 +92,7 @@ where
                 #[cfg(not(feature = "dash_debug"))]
                 resp.headers_mut().insert(
                     ACCESS_CONTROL_ALLOW_ORIGIN,
-                    header::HeaderValue::from_str(&format!("http://{}", origin)).unwrap(),
+                    header::HeaderValue::from_str(&format!("http://{origin}")).unwrap(),
                 );
                 #[cfg(feature = "dash_debug")]
                 resp.headers_mut().insert(

--- a/rita_common/src/network_endpoints/mod.rs
+++ b/rita_common/src/network_endpoints/mod.rs
@@ -23,7 +23,7 @@ pub async fn make_payments(item: Json<PaymentTx>) -> HttpResponse {
         checked: false,
     };
     if let Err(e) = validate_later(ts) {
-        return HttpResponse::build(StatusCode::from_u16(400u16).unwrap()).json(&format!("{}", e));
+        return HttpResponse::build(StatusCode::from_u16(400u16).unwrap()).json(&format!("{e}"));
     }
 
     HttpResponse::Ok().json("Payment Received!")
@@ -42,7 +42,7 @@ pub async fn make_payments_v2(item: Json<HashSet<PaymentTx>>) -> HttpResponse {
 
         // Duplicates will be removed here
         if let Err(e) = validate_later(ts) {
-            build_err.push_str(&format!("{}\n", e));
+            build_err.push_str(&format!("{e}\n"));
         }
     }
 

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -88,7 +88,7 @@ impl Display for PaymentControllerError {
         match self {
             Self::ResendFailed => write!(f, "Failed to resend txid after all attempts!"),
             Self::InsufficientFunds { amount, balance } => {
-                write!(f, "Can not send amount {} with balance {}", amount, balance)
+                write!(f, "Can not send amount {amount} with balance {balance}")
             }
             Self::ZeroPayment => write!(f, "Attempted to send zero value payment!"),
             Self::FailedToSendPayment => write!(f, "Failed to send payment!"),

--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -502,7 +502,7 @@ fn payment_is_old(chain_height: Uint256, tx_height: Option<Uint256>) -> bool {
 fn print_txids(list: &HashSet<ToValidate>) -> String {
     let mut output = String::new();
     for item in list.iter() {
-        write!(output, "{} ,", item).unwrap();
+        write!(output, "{item} ,").unwrap();
     }
     output
 }

--- a/rita_common/src/peer_listener/message.rs
+++ b/rita_common/src/peer_listener/message.rs
@@ -34,7 +34,7 @@ impl Display for MessageError {
             MessageError::InvalidPayloadError => write!(f, "Invalid payload detected"),
             MessageError::InvalidMagic => write!(f, "Invalid magic value received"),
             MessageError::BufferUnderflow => write!(f, "Buffer underflow while reading message"),
-            MessageError::IoError(ref e) => write!(f, "{}", e),
+            MessageError::IoError(ref e) => write!(f, "{e}"),
             MessageError::InvalidIpAddress => write!(f, "Received ImHere with invalid IP address"),
             MessageError::DeserializationError => {
                 write!(f, "Error when Deserializing Hello Message")

--- a/rita_common/src/token_bridge/mod.rs
+++ b/rita_common/src/token_bridge/mod.rs
@@ -19,6 +19,7 @@
 // simulate these, and those that pass are unlocked on the eth side. Funds are sent to their final
 // destination in dai
 
+#[cfg(test)]
 mod tests;
 pub mod xdai_bridge;
 

--- a/rita_common/src/token_bridge/mod.rs
+++ b/rita_common/src/token_bridge/mod.rs
@@ -3,66 +3,48 @@
 // through uniswap into DAI and then from there it is bridged over to the Xdai proof of authority chains.
 // Support for Cosmos chains using a DAI-pegged native currency is next on the list.
 
-// Essentially the goal is to allow users to deposit a popular and easy to acquire coin like Ethereum and then
+// Essentially the goal is to allow users to deposit a popular and easy to acquire coin on Ethereum and then
 // actually transact in a stablecoin on a fast blockchain, eg not Ethereum.
+
+// Currently this flow supports USDC, USDT, and DAI itself (v2 specifically)
 
 // This entire module works on the premise we call the conveyor belt model. It's difficult to track
 // money through this entire process exactly, in fact there are some edge cases where it's simply not
 // possible to reliably say if a task has completed or not. With that in mind we simply always progress
-// the the process for Eth -> DAI -> XDAI. So if we find
-// some DAI in our address it will always be converted to XDAI even if we didn't convert that DAI from Eth
-// in the first place.
+// the the process for Source coin -> DAI -> XDAI.
 
 // For the withdraw process we update a lazy static variable every time a withdraw is invoked.
 // Every tick, we check for updated withdraw information in the lazy static and use this to
 // initiate a withdrawal. From there, we loop to check for events related to the withdraws,
-// simulate these, and those that pass are unlocked on the eth side.
+// simulate these, and those that pass are unlocked on the eth side. Funds are sent to their final
+// destination in dai
+
+mod tests;
+pub mod xdai_bridge;
 
 use crate::rita_loop::slow_loop::SLOW_LOOP_TIMEOUT;
+use crate::token_bridge::xdai_bridge::*;
 use crate::RitaCommonError;
 use althea_types::SystemChain;
-use auto_bridge::check_relayed_message;
-use auto_bridge::get_payload_for_funds_unlock;
-use auto_bridge::HelperWithdrawInfo;
-use auto_bridge::ERC20_GAS_LIMIT;
-use auto_bridge::UNISWAP_GAS_LIMIT;
-use auto_bridge::XDAI_FUNDS_UNLOCK_GAS;
-use auto_bridge::{check_withdrawals, encode_relaytokens, get_relay_message_hash};
-use auto_bridge::{TokenBridge as TokenBridgeCore, TokenBridgeError};
-use clarity::utils::display_uint256_as_address;
+use auto_bridge::encode_relaytokens;
+use auto_bridge::TokenBridge as TokenBridgeCore;
 use clarity::Address;
-use futures::future::join3;
 use num256::Uint256;
-use num_traits::identities::Zero;
-use rand::{thread_rng, Rng};
 use settings::payment::PaymentSettings;
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::collections::VecDeque;
-use std::iter::FromIterator;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
-use web30::jsonrpc::error::Web3Error;
 
 lazy_static! {
     static ref BRIDGE: Arc<RwLock<TokenBridgeState>> =
         Arc::new(RwLock::new(TokenBridgeState::default()));
-    static ref AMOUNTS: Arc<RwLock<LastAmounts>> = Arc::new(RwLock::new(LastAmounts::default()));
-    /// This variable pushes gas prices every minute over the last 24 hours. New entries are pushed to the front
-    /// and older entries are popped from the back. The number of entries here is limited by the constant GAS_PRICE_ENTRIES
-    static ref GAS_PRICES: Arc<RwLock<VecDeque<Uint256>>> = Arc::new(RwLock::new(VecDeque::with_capacity(GAS_PRICE_ENTRIES)));
 }
 
 pub const ETH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(600);
-const UNISWAP_TIMEOUT: Duration = ETH_TRANSFER_TIMEOUT;
 
 const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000_u128;
 const SIGNATURES_TIMEOUT: Duration = ETH_TRANSFER_TIMEOUT;
 const BLOCKS: u64 = 40_032;
-/// This is the number of minutes in a day. We use this since we run the xdai_bridge every minute, therefore
-/// entering an entry every minute
-const GAS_PRICE_ENTRIES: usize = 1440;
 
 pub fn eth_to_wei(eth: u64) -> Uint256 {
     let wei = eth as u128 * WEI_PER_ETH;
@@ -126,338 +108,9 @@ impl Default for TokenBridgeState {
         TokenBridgeState {
             withdraw_in_progress: false,
             withdraw_details: None,
-            detailed_state: DetailedBridgeState::NoOp {
-                eth_balance: Uint256::zero(),
-                wei_per_dollar: Uint256::zero(),
-            },
+            detailed_state: DetailedBridgeState::NoOp,
         }
     }
-}
-
-/// Transfers dai present in eth address from previous xdai_bridge iterations to the xdai chain.
-/// This also assists in rescuing any stranded dai balance because of failures in depositing flow.
-async fn transfer_dai(
-    bridge: TokenBridgeCore,
-    our_address: Address,
-    minimum_stranded_dai_transfer: Uint256,
-) -> Result<(), TokenBridgeError> {
-    let dai_balance = bridge.get_dai_balance(our_address).await?;
-    info!("Our DAI balance is {}", dai_balance);
-    if dai_balance > minimum_stranded_dai_transfer {
-        info!("rescuing dais, failure to wait for event");
-        detailed_state_change(DetailedBridgeState::DaiToXdai {
-            amount: dai_balance.clone(),
-        });
-
-        // Remove up to U16_MAX wei from this transaction, this is well under a cent.
-        // what this does is randomly change the tx hash and help prevent 'stuck' transactions
-        // thanks to anti-spam mechanisms. Payments get this 'for free' thanks to changing debts
-        // numbers. And other tx's here do thanks to changing exchange rates and other external factors
-        // this is the only transaction that will be exactly the same for a very long period.
-        let mut rng = thread_rng();
-        let some_wei: u16 = rng.gen();
-        let amount = dai_balance - Uint256::from(some_wei);
-
-        // Over the bridge into xDai
-        bridge
-            .dai_to_xdai_bridge(amount, ETH_TRANSFER_TIMEOUT)
-            .await?;
-        Ok(())
-    } else {
-        // we don't have a lot of dai, we shouldn't do anything
-        Ok(())
-    }
-}
-
-/// The logic for the Eth -> Xdai bridge operation that runs every tick that also handles withdrawals.
-/// We start by checking the lazy static lock to check for any new withdrawals that were requested.
-/// If we find one, we initiate this withdrawal and reset the lock. Next we loop through events
-/// on the xdai blockchain to find any withdrawals related to us, and if so we unlock these funds.
-/// We then rescue any stuck dai and send any eth that we have over to the xdai chain.
-async fn xdai_bridge(bridge: TokenBridgeCore) {
-    let (eth_gas_price, wei_per_dollar, our_eth_balance) = join3(
-        bridge.eth_web3.eth_gas_price(),
-        bridge.dai_to_eth_price(eth_to_wei(1u8.into())),
-        bridge.eth_web3.eth_get_balance(bridge.own_address),
-    )
-    .await;
-    let eth_gas_price = match eth_gas_price {
-        Ok(val) => val,
-        Err(e) => {
-            warn!("Failed to get eth gas price with {}", e);
-            return;
-        }
-    };
-    let wei_per_dollar = match wei_per_dollar {
-        Ok(val) => val,
-        Err(e) => {
-            warn!("Failed to get eth price with {}", e);
-            return;
-        }
-    };
-    let wei_per_cent = wei_per_dollar.clone() / 100u32.into();
-    let our_eth_balance = match our_eth_balance {
-        Ok(val) => val,
-        Err(e) => {
-            warn!("Failed to get eth balance {}", e);
-            return;
-        }
-    };
-
-    let max_gas_price: Uint256;
-    {
-        // Add gas price entry to lazy static
-        let writer = &mut *GAS_PRICES.write().unwrap();
-        update_gas_price_store(eth_gas_price.clone(), writer);
-
-        // Get max acceptable gas price (within 20%)
-        max_gas_price = match get_acceptable_gas_price(eth_gas_price.clone(), writer) {
-            Ok(a) => a,
-            Err(_) => {
-                error!(
-                    "Not enough entries in gas price datastore, or error in datastore entry logic"
-                );
-                return;
-            }
-        };
-    }
-
-    // the amount of Eth to retain in WEI. This is the cost of our transfer from the
-    // xdai chain to the destination address.
-    let reserve_amount = get_reserve_amount(eth_gas_price.clone());
-    let minimum_to_exchange = reserve_amount.clone()
-        + (eth_gas_price.clone() * (UNISWAP_GAS_LIMIT + ERC20_GAS_LIMIT).into());
-    set_last_amounts(
-        lossy_u32(minimum_to_exchange.clone() / wei_per_cent.clone()),
-        lossy_u32(reserve_amount.clone() / wei_per_cent.clone()),
-    );
-    // the minimum amount to transfer, this is in DAI wei,
-    let minimum_stranded_dai_transfer = minimum_to_exchange.clone();
-
-    // initiate withdrawals if any, scope bridge write
-    {
-        let mut writer = get_bridge_state();
-        if writer.withdraw_in_progress {
-            let withdraw_details = match &writer.withdraw_details {
-                Some(a) => a.clone(),
-                None => {
-                    error!("No withdraw information present");
-                    writer.withdraw_in_progress = false;
-                    set_bridge_state(writer.clone());
-                    return;
-                }
-            };
-            let amount = withdraw_details.amount.clone();
-            let address = withdraw_details.to;
-            match withdraw(withdraw_details).await {
-                Ok(_) => {
-                    info!(
-                        "Initiating withdrawal of amount {} to address {}",
-                        amount, address
-                    );
-                }
-                Err(e) => error!("Received an error when initiating a withdrawal: {}", e),
-            };
-
-            //reset the withdraw lock
-            writer.withdraw_in_progress = false;
-            writer.withdraw_details = None;
-            set_bridge_state(writer);
-        }
-    }
-
-    // check for withdrawal events and execute them
-    match simulated_withdrawal_on_eth(&bridge, wei_per_dollar.clone()).await {
-        Ok(()) => {
-            info!(
-                "Checking for withdraw events related to us (address: {})",
-                bridge.own_address
-            );
-        }
-        Err(e) => {
-            info!("Received error when trying to unlock funds: {}", e);
-        }
-    }
-
-    //run these deposit steps only if gas price is low
-    if max_gas_price < eth_gas_price {
-        warn!("Gas prices too high this iteration");
-        return;
-    }
-
-    // transfer dai exchanged from eth during previous iterations
-    let res = transfer_dai(
-        bridge.clone(),
-        bridge.own_address,
-        minimum_stranded_dai_transfer,
-    )
-    .await;
-    if res.is_err() {
-        warn!("Failed to transfer dai with {:?}", res);
-    }
-    trace!("Transfered dai");
-
-    // run the conveyor belt eth -> xdai
-    if our_eth_balance >= minimum_to_exchange {
-        // Leave a reserve in the account to use for gas in the future
-        let swap_amount = our_eth_balance - reserve_amount;
-
-        detailed_state_change(DetailedBridgeState::EthToDai {
-            amount_of_eth: swap_amount.clone(),
-            wei_per_dollar,
-        });
-
-        info!("Converting to Dai");
-        let _dai_bought = match bridge.eth_to_dai_swap(swap_amount, UNISWAP_TIMEOUT).await {
-            Ok(val) => val,
-            Err(e) => {
-                warn!("Failed to swap dai with {:?}", e);
-                return;
-            }
-        };
-    } else {
-        detailed_state_change(DetailedBridgeState::NoOp {
-            eth_balance: our_eth_balance,
-            wei_per_dollar,
-        });
-    }
-}
-
-/// This helper function adds a gas price entry to the GAS_PRICES data store.
-fn update_gas_price_store(gp: Uint256, datastore: &mut VecDeque<Uint256>) {
-    match datastore.len().cmp(&GAS_PRICE_ENTRIES) {
-        Ordering::Less => datastore.push_front(gp),
-        Ordering::Equal => {
-            //vec is full, remove oldest entry
-            datastore.pop_back();
-            datastore.push_front(gp);
-        }
-        Ordering::Greater => {
-            panic!("Vec size greater than max size, error in GAS_PRICES vecDeque logic")
-        }
-    }
-}
-
-/// Look thorugh all the gas prices in the last 24 hours and determine the highest
-/// acceptabe price to pay (bottom 20% of gas prices in last 24 hours)
-fn get_acceptable_gas_price(
-    eth_gas_price: Uint256,
-    datastore: &VecDeque<Uint256>,
-) -> Result<Uint256, RitaCommonError> {
-    // if there are no entries, return current gas price as acceptable
-    // We should not reach this condition since we alway call update_gas_price_store
-    // before calling this function
-    if datastore.is_empty() {
-        return Ok(eth_gas_price);
-    }
-
-    let vector = datastore.clone();
-    let mut vector: Vec<Uint256> = Vec::from_iter(vector);
-    vector.sort();
-
-    //find gas price in lowest 20%
-    let lowest_20: usize = (0.2_f32 * vector.len() as f32).ceil() as usize;
-    let value = match vector.get(lowest_20 - 1) {
-        Some(a) => a.clone(),
-        None => return Err(RitaCommonError::Lowest20Error(lowest_20 - 1)),
-    };
-    Ok(value)
-}
-
-/// This function is called inside the bridge loop. It retrieves the 'n' most recent blocks
-/// (where 'n' is the const 'BLOCKS' that is currently set to 40,032, which represents 1 week of blocks on xdai chain) that
-/// have withdraw events related to our address. It then simulates these events and submits
-/// the signatures needed to unlock the funds.
-async fn simulated_withdrawal_on_eth(
-    bridge: &TokenBridgeCore,
-    wei_per_dollar: Uint256,
-) -> Result<(), TokenBridgeError> {
-    let client = bridge.xdai_web3.clone();
-    let mut h = HashSet::new();
-    h.insert(bridge.own_address);
-
-    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h).await?;
-
-    for event in events.iter() {
-        let txid = event.txid.clone();
-        let amount = event.amount.clone();
-        let w_p_dollar = wei_per_dollar.clone();
-
-        let withdraw_info = get_relay_message_hash(
-            bridge.own_address,
-            bridge.xdai_web3.clone(),
-            bridge.helper_on_xdai,
-            event.receiver,
-            txid.clone(),
-            amount.clone(),
-        )
-        .await?;
-
-        // check if the event has already unlocked the funds or not
-        let res = match check_relayed_message(
-            event.txid.clone(),
-            bridge.eth_web3.clone(),
-            bridge.own_address,
-            bridge.xdai_bridge_on_eth,
-        )
-        .await
-        {
-            Ok(a) => a,
-            Err(e) => {
-                error!(
-                    "Received Error when checking for signature 'relayedMessages': {}, skipping",
-                    e
-                );
-                continue;
-            }
-        };
-
-        if res {
-            trace!(
-                "Transaction with Id: {} has already been unlocked, skipping",
-                display_uint256_as_address(txid.clone())
-            );
-            continue;
-        } else {
-            //unlock this transaction
-            trace!(
-                "Tx Hash is {} with the amount of {} for a withdraw event",
-                display_uint256_as_address(txid.clone()),
-                amount
-            );
-            let _res = bridge
-                .submit_signatures_to_unlock_funds(withdraw_info, SIGNATURES_TIMEOUT)
-                .await?;
-            detailed_state_change(DetailedBridgeState::DaiToDest {
-                amount_of_dai: amount,
-                wei_per_dollar: w_p_dollar,
-                dest_address: event.receiver,
-            });
-        }
-    }
-
-    Ok(())
-}
-
-/// This function simulates the withdraw event given to it. Based on this information, we can decide if we want to
-/// process this transaction by using real money. This allows us to unlock the funds on the 'eth' side. This function is currently not in use
-/// and we use check_relayed_message() instead for simplicity.
-#[allow(dead_code)]
-async fn simulate_signature_submission(
-    bridge: &TokenBridgeCore,
-    data: &HelperWithdrawInfo,
-) -> Result<Vec<u8>, Web3Error> {
-    let payload = get_payload_for_funds_unlock(data);
-    bridge
-        .eth_web3
-        .simulate_transaction(
-            bridge.xdai_bridge_on_eth,
-            0_u32.into(),
-            payload,
-            bridge.own_address,
-            None,
-        )
-        .await
 }
 
 /// Withdraw state struct for the bridge, if withdraw_all is true, the eth will be
@@ -549,51 +202,29 @@ fn detailed_state_change(msg: DetailedBridgeState) {
     bridge.detailed_state = new_state;
 }
 
-fn set_last_amounts(minimum_to_exchange: u32, reserve_amount: u32) {
-    let mut amounts = AMOUNTS.write().unwrap();
-    *amounts = LastAmounts {
-        minimum_to_exchange,
-        reserve_amount,
-    };
-}
-
 /// Used to display the state of the bridge to the user, has a higher
 /// resolution than the actual bridge state object in exchange for possibly
 /// being inaccurate or going backwards
 #[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub enum DetailedBridgeState {
-    /// Converting Eth to Dai
-    EthToDai {
-        amount_of_eth: Uint256,
-        wei_per_dollar: Uint256,
-    },
+    /// Swapping any input token for dai
+    Swap,
     /// Converting Dai to Xdai
     DaiToXdai { amount: Uint256 },
     /// Converting Xdai to Dai
     XdaiToDai { amount: Uint256 },
-    /// Converting Dai to Eth
-    DaiToEth {
-        amount_of_dai: Uint256,
-        wei_per_dollar: Uint256,
-    },
     DaiToDest {
         amount_of_dai: Uint256,
-        wei_per_dollar: Uint256,
         dest_address: Address,
     },
     /// Nothing is happening
-    NoOp {
-        eth_balance: Uint256,
-        wei_per_dollar: Uint256,
-    },
+    NoOp,
 }
 
 /// Contains everything a user facing application would need to help a user
 /// interact with the bridge
 #[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub struct BridgeStatus {
-    reserve_amount: u32,
-    minimum_deposit: u32,
     withdraw_chain: SystemChain,
     state: DetailedBridgeState,
 }
@@ -603,432 +234,8 @@ pub fn get_bridge_status() -> BridgeStatus {
     let withdraw_chain = payment_settings.withdraw_chain;
     drop(payment_settings);
     let bridge = BRIDGE.read().unwrap().clone();
-    // amounts is in cents, we need to convert to dollars for the dashboard display
-    let amounts = AMOUNTS.read().unwrap().clone();
-    let reserve_amount = amounts.reserve_amount / 100;
-    let minimum_to_exchange = amounts.minimum_to_exchange / 100;
     BridgeStatus {
-        reserve_amount,
-        minimum_deposit: minimum_to_exchange,
         withdraw_chain,
         state: bridge.detailed_state,
-    }
-}
-
-/// the amount of Eth to retain in WEI. This is the cost of our Uniswap exchange an ERC20 transfer
-/// and one ETH transfer. To pay for Uniswap -> send to bridge and keep enough around for a withdraw
-/// which involves a Uniswap exchange -> Eth send (since the ERC20 send is paid by the bridge)
-/// this ensures that a withdraw is always possible. Currently we have reduced this to only ensure
-/// that the deposit goes through. Because reserving enough funds is too expensive.
-fn get_reserve_amount(eth_gas_price: Uint256) -> Uint256 {
-    // eth_gas_price * (ERC20_GAS_LIMIT + (UNISWAP_GAS_LIMIT * 2) + ETH_TRANSACTION_GAS_LIMIT).into()
-    eth_gas_price * (XDAI_FUNDS_UNLOCK_GAS).into()
-}
-
-fn lossy_u32(input: Uint256) -> u32 {
-    match input.to_string().parse() {
-        Ok(val) => val,
-        // the only possible error the number being too large, both are unsigned. String formatting
-        // won't change etc.
-        Err(_e) => u32::MAX,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-    use auto_bridge::default_bridge_addresses;
-    use auto_bridge::TokenBridge;
-    use clarity::PrivateKey;
-    use std::str::FromStr;
-
-    const TIMEOUT: Duration = Duration::from_secs(600);
-
-    /// This simply test that the lazy static lock is being updated correctly after calling the function setup_withdrawal.
-    /// We call the function with the 'Withdraw' struct and check if the information is being updated correctly. This is necessary
-    /// that the correct information about the withdrawal is being processed.
-    #[test]
-    fn test_xdai_setup_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let _bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address);
-        if address.is_err() {
-            panic!("withdraw address is wrong");
-        }
-        let withdraw = Withdraw {
-            to: address.unwrap(),
-            amount: 11646660293665450_u64.into(),
-        };
-
-        println!("ready for setup");
-        let res = setup_withdraw(withdraw.clone());
-        if res.is_err() {
-            panic!("Error with setup withdrawal");
-        }
-
-        println!("setup done");
-
-        let reader = BRIDGE.read().unwrap();
-        let withdraw_setup = match &reader.withdraw_details {
-            Some(a) => a.clone(),
-            None => panic!("No value set in withdraw setup"),
-        };
-
-        //check lazy static
-        assert!(reader.withdraw_in_progress);
-        assert_eq!(withdraw_setup, withdraw);
-    }
-
-    /// Calls the encode_relaytokens and initiates the withdrawal process from xdai chain to an external address. Does not however unlock the funds on the eth side.
-    /// Refer to test_xdai_unlock_withdraw() to check unlocking funds
-    #[test]
-    #[ignore]
-    fn test_xdai_transfer_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address);
-        if address.is_err() {
-            panic!("withdraw address is wrong");
-        }
-        let to = address.unwrap();
-        //10 xdai
-        let amount = 10000000000000000000_u128;
-
-        //Run the withdrawal process
-        let runner = actix_async::System::new();
-        runner.block_on(async move {
-            //do encode relay token call with our token bridge
-            let res = encode_relaytokens(bridge, to, amount.into(), Duration::from_secs(600)).await;
-            match res {
-                Ok(_) => println!("withdraw successful to address {}", to),
-                Err(e) => panic!("Error during withdraw: {}", e),
-            }
-        })
-    }
-
-    /// This tests the the funds that were initially transfered by test_xdai_transfer_withdraw can we unlocked, Note that the event you are trying to unlock
-    /// needs to be within 40k blocks of the current xdai chain block height, or the withdraw event will not be found.
-    #[test]
-    #[ignore]
-    fn test_xdai_unlock_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let runner = actix_async::System::new();
-
-        runner.block_on(async move {
-            let wei_per_dollar = match bridge.dai_to_eth_price(eth_to_wei(1u8.into())).await {
-                Ok(val) => val,
-                Err(e) => {
-                    warn!("Failed to get eth price with {}", e);
-                    return;
-                }
-            };
-
-            match simulated_withdrawal_on_eth(&bridge, wei_per_dollar.clone()).await {
-                Ok(()) => {
-                    println!(
-                        "Checking for withdraw events related to us (address: {})",
-                        bridge.own_address
-                    );
-                }
-                Err(e) => {
-                    println!("Received error when trying to unlock funds: {}", e);
-                }
-            }
-        })
-    }
-
-    /// This tests the function simulate_signature_submission(), which is used to tests if a transaction needs to be unlocked on eth side or not.
-    /// This function not currently in use and we instead use check_relayed_message because of simplicity, but simulate_signature_submission() is also functional and
-    /// checks the same thing as check_relayed_message() does.
-    #[test]
-    #[ignore]
-    fn test_simulate_unlock_funds() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address).unwrap();
-
-        let tx_hash = "0xf75cd74e3643bb0d17780589e0f18840c89ff77532f5ac38fbff885468091620";
-        let tx_hash = Uint256::from_str(tx_hash).unwrap();
-
-        let amount = 10000000000000000000_u128;
-
-        let runner = actix_async::System::new();
-
-        runner.block_on(async move {
-            let withdraw_info = get_relay_message_hash(
-                bridge.own_address,
-                bridge.xdai_web3.clone(),
-                bridge.helper_on_xdai,
-                address,
-                tx_hash,
-                amount.into(),
-            )
-            .await
-            .unwrap();
-
-            match simulate_signature_submission(&bridge, &withdraw_info).await {
-                Ok(_) => println!("Successful simulation"),
-                Err(e) => println!("Simulation failed {}", e),
-            }
-        })
-    }
-
-    /// Tests the deposit flow of funds from eth to dai on xdai chain. First converts eth to dai, reserving an amount
-    /// to pay for withdrawal. Then transfer this amount over to the xdai chain.
-    #[test]
-    #[ignore]
-    fn test_deposit_flow() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let runner = actix_async::System::new();
-        runner.block_on(async move {
-            let eth_gas_price = match bridge.eth_web3.eth_gas_price().await {
-                Ok(val) => val,
-                Err(e) => {
-                    panic!("Failed to get eth gas price with {}", e);
-                }
-            };
-
-            let reserve_amount = get_reserve_amount(eth_gas_price.clone());
-            println!("reserve amount is {}", reserve_amount);
-            let minimum_to_exchange = reserve_amount.clone()
-                + (eth_gas_price.clone() * (UNISWAP_GAS_LIMIT + ERC20_GAS_LIMIT).into());
-            println!("Mnimum to exchnage is {}", minimum_to_exchange);
-
-            let our_eth_balance = match bridge.eth_web3.eth_get_balance(bridge.own_address).await {
-                Ok(val) => val,
-                Err(e) => {
-                    panic!("Failed to get eth balance {}", e);
-                }
-            };
-            println!("Our eth balance is {}", our_eth_balance);
-
-            // run the conveyor belt eth -> xdai
-            if our_eth_balance >= minimum_to_exchange {
-                // Leave a reserve in the account to use for gas in the future
-                let swap_amount = our_eth_balance - reserve_amount;
-
-                let dai_bought = match bridge.eth_to_dai_swap(swap_amount, UNISWAP_TIMEOUT).await {
-                    Ok(val) => val,
-                    Err(e) => {
-                        panic!("Failed to swap dai with {:?}", e);
-                    }
-                };
-                println!("received dai: {}", dai_bought);
-
-                // And over the bridge into xDai
-                let _res = bridge
-                    .dai_to_xdai_bridge(dai_bought, ETH_TRANSFER_TIMEOUT)
-                    .await;
-            } else {
-                println!("ETH BALANCE IS NOT GREATER THAN MIN");
-            }
-        })
-    }
-
-    /// Tests that funds in dai are being transfered over to the xdai blockchain as long as dai funds are greater than
-    /// minimum amount to exchange (cost of a withdrawal + cost of swap to dai + cost of transfer)
-    #[test]
-    #[ignore]
-    fn test_transfer_dai() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let runner = actix_async::System::new();
-        runner.block_on(async move {
-            let eth_gas_price = match bridge.eth_web3.eth_gas_price().await {
-                Ok(val) => val,
-                Err(e) => {
-                    panic!("Failed to get eth gas price with {}", e);
-                }
-            };
-            let reserve_amount = get_reserve_amount(eth_gas_price.clone());
-
-            let minimum_to_exchange = reserve_amount.clone()
-                + (eth_gas_price.clone() * (UNISWAP_GAS_LIMIT + ERC20_GAS_LIMIT).into());
-
-            let res = transfer_dai(bridge.clone(), bridge.own_address, minimum_to_exchange).await;
-            if res.is_err() {
-                panic!("Failed to rescue dai with {:?}", res);
-            }
-        })
-    }
-
-    /// This test the function update_gas_price_store to check if the lazy static would be updated
-    /// correctly, both for when the queue size is less that max capacity and for when it is at max
-    /// capacity
-    #[test]
-    fn test_update_gas_price_store() {
-        let mut vec: VecDeque<Uint256> = VecDeque::with_capacity(GAS_PRICE_ENTRIES);
-        assert_eq!(vec.len(), 0);
-
-        update_gas_price_store(12_u32.into(), &mut vec);
-
-        assert_eq!(vec.len(), 1);
-        assert_eq!(
-            vec.get(0).unwrap().clone(),
-            Uint256::from_bytes_be(&[12_u8])
-        );
-
-        let append_vec = vec![Uint256::from_bytes_be(&[12_u8]); 1439];
-
-        vec.append(&mut VecDeque::from(append_vec));
-
-        assert_eq!(vec.len(), GAS_PRICE_ENTRIES);
-
-        update_gas_price_store(11_u32.into(), &mut vec);
-
-        // Vec size should not exceed GAS_PRICE_ENTRIES and eariliest elemtn should match what we just added.
-        assert_eq!(vec.len(), GAS_PRICE_ENTRIES);
-        assert_eq!(
-            vec.get(0).unwrap().clone(),
-            Uint256::from_bytes_be(&[11_u8])
-        );
-    }
-
-    /// Test the function get_acceptable_gas_price, which contains logic for getting the max threshold
-    /// for the bottom 20% of prices in datastore. Tests various scenarios such as empty queue and odd
-    /// number of elements in datastore
-    #[test]
-    fn test_get_acceptable_gas_price() {
-        let mut vec: VecDeque<Uint256> = VecDeque::with_capacity(GAS_PRICE_ENTRIES);
-        let eth_gas_price = Uint256::from_bytes_be(&[12_u8]);
-
-        // when datastore is empty, return current gas price
-        let res = get_acceptable_gas_price(eth_gas_price.clone(), &vec).unwrap();
-        assert_eq!(eth_gas_price, res);
-
-        // when datastore has one element, return it
-        vec.push_front(12_u32.into());
-        let res = get_acceptable_gas_price(eth_gas_price.clone(), &vec).unwrap();
-        assert_eq!(res, eth_gas_price);
-        vec.pop_front();
-
-        // when datastore has multiple elements, calculate bottom 20% and return threshold value
-        let append_vec: Vec<Uint256> = vec![
-            1_u32.into(),
-            2_u32.into(),
-            3_u32.into(),
-            4_u32.into(),
-            5_u32.into(),
-            6_u32.into(),
-            7_u32.into(),
-            8_u32.into(),
-            9_u32.into(),
-            10_u32.into(),
-        ];
-        assert_eq!(vec.len(), 0);
-        vec.append(&mut VecDeque::from(append_vec));
-        assert_eq!(vec.len(), 10);
-        let res = get_acceptable_gas_price(eth_gas_price.clone(), &vec).unwrap();
-        assert_eq!(res, Uint256::from_bytes_be(&[2_u8]));
-
-        //test for random order in datastore
-        vec.clear();
-        assert_eq!(vec.len(), 0);
-        let append_vec: Vec<Uint256> = vec![
-            10_u32.into(),
-            5_u32.into(),
-            3_u32.into(),
-            7_u32.into(),
-            8_u32.into(),
-            6_u32.into(),
-            2_u32.into(),
-            1_u32.into(),
-            9_u32.into(),
-            4_u32.into(),
-        ];
-        vec.append(&mut VecDeque::from(append_vec));
-        assert_eq!(vec.len(), 10);
-        let res = get_acceptable_gas_price(eth_gas_price.clone(), &vec).unwrap();
-        assert_eq!(res, Uint256::from_bytes_be(&[2_u8]));
-
-        //test for odd nubmer of elements in datastore
-        vec.push_front(0_u32.into());
-        assert_eq!(vec.len(), 11);
-        let res = get_acceptable_gas_price(eth_gas_price, &vec).unwrap();
-        assert_eq!(res, Uint256::from_bytes_be(&[2_u8]));
     }
 }

--- a/rita_common/src/token_bridge/tests.rs
+++ b/rita_common/src/token_bridge/tests.rs
@@ -1,222 +1,218 @@
-#[cfg(test)]
-mod tests {
+use crate::token_bridge::xdai_bridge::*;
+use crate::token_bridge::*;
+use auto_bridge::default_bridge_addresses;
+use auto_bridge::TokenBridge;
+use auto_bridge::{encode_relaytokens, get_relay_message_hash};
+use clarity::Address;
+use clarity::PrivateKey;
+use num256::Uint256;
+use std::str::FromStr;
+use std::time::Duration;
 
-    use crate::token_bridge::xdai_bridge::*;
-    use crate::token_bridge::*;
-    use auto_bridge::default_bridge_addresses;
-    use auto_bridge::TokenBridge;
-    use auto_bridge::{encode_relaytokens, get_relay_message_hash};
-    use clarity::Address;
-    use clarity::PrivateKey;
-    use num256::Uint256;
-    use std::str::FromStr;
-    use std::time::Duration;
+const TIMEOUT: Duration = Duration::from_secs(600);
 
-    const TIMEOUT: Duration = Duration::from_secs(600);
+/// This simply test that the lazy static lock is being updated correctly after calling the function setup_withdrawal.
+/// We call the function with the 'Withdraw' struct and check if the information is being updated correctly. This is necessary
+/// that the correct information about the withdrawal is being processed.
+#[test]
+fn test_xdai_setup_withdraw() {
+    let pk = PrivateKey::from_str(&format!(
+        "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+        "632c1e54099", "51b0281"
+    ))
+    .unwrap();
 
-    /// This simply test that the lazy static lock is being updated correctly after calling the function setup_withdrawal.
-    /// We call the function with the 'Withdraw' struct and check if the information is being updated correctly. This is necessary
-    /// that the correct information about the withdrawal is being processed.
-    #[test]
-    fn test_xdai_setup_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
+    let _bridge = TokenBridge::new(
+        default_bridge_addresses(),
+        pk.to_address(),
+        pk,
+        "https://eth.altheamesh.com".into(),
+        "https://dai.altheamesh.com".into(),
+        TIMEOUT,
+    );
+
+    let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+    let address = Address::parse_and_validate(address);
+    if address.is_err() {
+        panic!("withdraw address is wrong");
+    }
+    let withdraw = Withdraw {
+        to: address.unwrap(),
+        amount: 11646660293665450_u64.into(),
+    };
+
+    println!("ready for setup");
+    let res = setup_withdraw(withdraw.clone());
+    if res.is_err() {
+        panic!("Error with setup withdrawal");
+    }
+
+    println!("setup done");
+
+    let reader = BRIDGE.read().unwrap();
+    let withdraw_setup = match &reader.withdraw_details {
+        Some(a) => a.clone(),
+        None => panic!("No value set in withdraw setup"),
+    };
+
+    //check lazy static
+    assert!(reader.withdraw_in_progress);
+    assert_eq!(withdraw_setup, withdraw);
+}
+
+/// Calls the encode_relaytokens and initiates the withdrawal process from xdai chain to an external address. Does not however unlock the funds on the eth side.
+/// Refer to test_xdai_unlock_withdraw() to check unlocking funds
+#[test]
+#[ignore]
+fn test_xdai_transfer_withdraw() {
+    let pk = PrivateKey::from_str(&format!(
+        "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+        "632c1e54099", "51b0281"
+    ))
+    .unwrap();
+
+    let bridge = TokenBridge::new(
+        default_bridge_addresses(),
+        pk.to_address(),
+        pk,
+        "https://eth.altheamesh.com".into(),
+        "https://dai.altheamesh.com".into(),
+        TIMEOUT,
+    );
+
+    let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+    let address = Address::parse_and_validate(address);
+    if address.is_err() {
+        panic!("withdraw address is wrong");
+    }
+    let to = address.unwrap();
+    //10 xdai
+    let amount = 10000000000000000000_u128;
+
+    //Run the withdrawal process
+    let runner = actix_async::System::new();
+    runner.block_on(async move {
+        //do encode relay token call with our token bridge
+        let res = encode_relaytokens(bridge, to, amount.into(), Duration::from_secs(600)).await;
+        match res {
+            Ok(_) => println!("withdraw successful to address {to}"),
+            Err(e) => panic!("Error during withdraw: {}", e),
+        }
+    })
+}
+
+/// This tests the the funds that were initially transfered by test_xdai_transfer_withdraw can we unlocked, Note that the event you are trying to unlock
+/// needs to be within 40k blocks of the current xdai chain block height, or the withdraw event will not be found.
+#[test]
+#[ignore]
+fn test_xdai_unlock_withdraw() {
+    let pk = PrivateKey::from_str(&format!(
+        "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+        "632c1e54099", "51b0281"
+    ))
+    .unwrap();
+
+    let bridge = TokenBridge::new(
+        default_bridge_addresses(),
+        pk.to_address(),
+        pk,
+        "https://eth.altheamesh.com".into(),
+        "https://dai.altheamesh.com".into(),
+        TIMEOUT,
+    );
+
+    let runner = actix_async::System::new();
+
+    runner.block_on(async move {
+        match simulated_withdrawal_on_eth(&bridge).await {
+            Ok(()) => {
+                println!(
+                    "Checking for withdraw events related to us (address: {})",
+                    bridge.own_address
+                );
+            }
+            Err(e) => {
+                println!("Received error when trying to unlock funds: {e}");
+            }
+        }
+    })
+}
+
+/// This tests the function simulate_signature_submission(), which is used to tests if a transaction needs to be unlocked on eth side or not.
+/// This function not currently in use and we instead use check_relayed_message because of simplicity, but simulate_signature_submission() is also functional and
+/// checks the same thing as check_relayed_message() does.
+#[test]
+#[ignore]
+fn test_simulate_unlock_funds() {
+    let pk = PrivateKey::from_str(&format!(
+        "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+        "632c1e54099", "51b0281"
+    ))
+    .unwrap();
+
+    let bridge = TokenBridge::new(
+        default_bridge_addresses(),
+        pk.to_address(),
+        pk,
+        "https://eth.altheamesh.com".into(),
+        "https://dai.altheamesh.com".into(),
+        TIMEOUT,
+    );
+
+    let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+    let address = Address::parse_and_validate(address).unwrap();
+
+    let tx_hash = "0xf75cd74e3643bb0d17780589e0f18840c89ff77532f5ac38fbff885468091620";
+    let tx_hash = Uint256::from_str(tx_hash).unwrap();
+
+    let amount = 10000000000000000000_u128;
+
+    let runner = actix_async::System::new();
+
+    runner.block_on(async move {
+        let withdraw_info = get_relay_message_hash(
+            bridge.own_address,
+            bridge.xdai_web3.clone(),
+            bridge.helper_on_xdai,
+            address,
+            tx_hash,
+            amount.into(),
+        )
+        .await
         .unwrap();
 
-        let _bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address);
-        if address.is_err() {
-            panic!("withdraw address is wrong");
+        match simulate_signature_submission(&bridge, &withdraw_info).await {
+            Ok(_) => println!("Successful simulation"),
+            Err(e) => println!("Simulation failed {e}"),
         }
-        let withdraw = Withdraw {
-            to: address.unwrap(),
-            amount: 11646660293665450_u64.into(),
-        };
+    })
+}
 
-        println!("ready for setup");
-        let res = setup_withdraw(withdraw.clone());
+/// Tests that funds in dai are being transfered over to the xdai blockchain as long as dai funds are greater than
+/// minimum amount to exchange (cost of a withdrawal + cost of swap to dai + cost of transfer)
+#[test]
+#[ignore]
+fn test_transfer_dai() {
+    let pk = PrivateKey::from_str(&format!(
+        "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+        "632c1e54099", "51b0281"
+    ))
+    .unwrap();
+
+    let bridge = TokenBridge::new(
+        default_bridge_addresses(),
+        pk.to_address(),
+        pk,
+        "https://eth.altheamesh.com".into(),
+        "https://dai.altheamesh.com".into(),
+        TIMEOUT,
+    );
+
+    let runner = actix_async::System::new();
+    runner.block_on(async move {
+        let res = transfer_dai(bridge.clone(), bridge.get_dai_balance().await.unwrap()).await;
         if res.is_err() {
-            panic!("Error with setup withdrawal");
+            panic!("Failed to rescue dai with {:?}", res);
         }
-
-        println!("setup done");
-
-        let reader = BRIDGE.read().unwrap();
-        let withdraw_setup = match &reader.withdraw_details {
-            Some(a) => a.clone(),
-            None => panic!("No value set in withdraw setup"),
-        };
-
-        //check lazy static
-        assert!(reader.withdraw_in_progress);
-        assert_eq!(withdraw_setup, withdraw);
-    }
-
-    /// Calls the encode_relaytokens and initiates the withdrawal process from xdai chain to an external address. Does not however unlock the funds on the eth side.
-    /// Refer to test_xdai_unlock_withdraw() to check unlocking funds
-    #[test]
-    #[ignore]
-    fn test_xdai_transfer_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address);
-        if address.is_err() {
-            panic!("withdraw address is wrong");
-        }
-        let to = address.unwrap();
-        //10 xdai
-        let amount = 10000000000000000000_u128;
-
-        //Run the withdrawal process
-        let runner = actix_async::System::new();
-        runner.block_on(async move {
-            //do encode relay token call with our token bridge
-            let res = encode_relaytokens(bridge, to, amount.into(), Duration::from_secs(600)).await;
-            match res {
-                Ok(_) => println!("withdraw successful to address {}", to),
-                Err(e) => panic!("Error during withdraw: {}", e),
-            }
-        })
-    }
-
-    /// This tests the the funds that were initially transfered by test_xdai_transfer_withdraw can we unlocked, Note that the event you are trying to unlock
-    /// needs to be within 40k blocks of the current xdai chain block height, or the withdraw event will not be found.
-    #[test]
-    #[ignore]
-    fn test_xdai_unlock_withdraw() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let runner = actix_async::System::new();
-
-        runner.block_on(async move {
-            match simulated_withdrawal_on_eth(&bridge).await {
-                Ok(()) => {
-                    println!(
-                        "Checking for withdraw events related to us (address: {})",
-                        bridge.own_address
-                    );
-                }
-                Err(e) => {
-                    println!("Received error when trying to unlock funds: {}", e);
-                }
-            }
-        })
-    }
-
-    /// This tests the function simulate_signature_submission(), which is used to tests if a transaction needs to be unlocked on eth side or not.
-    /// This function not currently in use and we instead use check_relayed_message because of simplicity, but simulate_signature_submission() is also functional and
-    /// checks the same thing as check_relayed_message() does.
-    #[test]
-    #[ignore]
-    fn test_simulate_unlock_funds() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
-        let address = Address::parse_and_validate(address).unwrap();
-
-        let tx_hash = "0xf75cd74e3643bb0d17780589e0f18840c89ff77532f5ac38fbff885468091620";
-        let tx_hash = Uint256::from_str(tx_hash).unwrap();
-
-        let amount = 10000000000000000000_u128;
-
-        let runner = actix_async::System::new();
-
-        runner.block_on(async move {
-            let withdraw_info = get_relay_message_hash(
-                bridge.own_address,
-                bridge.xdai_web3.clone(),
-                bridge.helper_on_xdai,
-                address,
-                tx_hash,
-                amount.into(),
-            )
-            .await
-            .unwrap();
-
-            match simulate_signature_submission(&bridge, &withdraw_info).await {
-                Ok(_) => println!("Successful simulation"),
-                Err(e) => println!("Simulation failed {}", e),
-            }
-        })
-    }
-
-    /// Tests that funds in dai are being transfered over to the xdai blockchain as long as dai funds are greater than
-    /// minimum amount to exchange (cost of a withdrawal + cost of swap to dai + cost of transfer)
-    #[test]
-    #[ignore]
-    fn test_transfer_dai() {
-        let pk = PrivateKey::from_str(&format!(
-            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
-            "632c1e54099", "51b0281"
-        ))
-        .unwrap();
-
-        let bridge = TokenBridge::new(
-            default_bridge_addresses(),
-            pk.to_address(),
-            pk,
-            "https://eth.altheamesh.com".into(),
-            "https://dai.altheamesh.com".into(),
-            TIMEOUT,
-        );
-
-        let runner = actix_async::System::new();
-        runner.block_on(async move {
-            let res = transfer_dai(bridge.clone(), bridge.get_dai_balance().await.unwrap()).await;
-            if res.is_err() {
-                panic!("Failed to rescue dai with {:?}", res);
-            }
-        })
-    }
+    })
 }

--- a/rita_common/src/token_bridge/tests.rs
+++ b/rita_common/src/token_bridge/tests.rs
@@ -1,0 +1,222 @@
+#[cfg(test)]
+mod tests {
+
+    use crate::token_bridge::xdai_bridge::*;
+    use crate::token_bridge::*;
+    use auto_bridge::default_bridge_addresses;
+    use auto_bridge::TokenBridge;
+    use auto_bridge::{encode_relaytokens, get_relay_message_hash};
+    use clarity::Address;
+    use clarity::PrivateKey;
+    use num256::Uint256;
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    const TIMEOUT: Duration = Duration::from_secs(600);
+
+    /// This simply test that the lazy static lock is being updated correctly after calling the function setup_withdrawal.
+    /// We call the function with the 'Withdraw' struct and check if the information is being updated correctly. This is necessary
+    /// that the correct information about the withdrawal is being processed.
+    #[test]
+    fn test_xdai_setup_withdraw() {
+        let pk = PrivateKey::from_str(&format!(
+            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+            "632c1e54099", "51b0281"
+        ))
+        .unwrap();
+
+        let _bridge = TokenBridge::new(
+            default_bridge_addresses(),
+            pk.to_address(),
+            pk,
+            "https://eth.altheamesh.com".into(),
+            "https://dai.altheamesh.com".into(),
+            TIMEOUT,
+        );
+
+        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+        let address = Address::parse_and_validate(address);
+        if address.is_err() {
+            panic!("withdraw address is wrong");
+        }
+        let withdraw = Withdraw {
+            to: address.unwrap(),
+            amount: 11646660293665450_u64.into(),
+        };
+
+        println!("ready for setup");
+        let res = setup_withdraw(withdraw.clone());
+        if res.is_err() {
+            panic!("Error with setup withdrawal");
+        }
+
+        println!("setup done");
+
+        let reader = BRIDGE.read().unwrap();
+        let withdraw_setup = match &reader.withdraw_details {
+            Some(a) => a.clone(),
+            None => panic!("No value set in withdraw setup"),
+        };
+
+        //check lazy static
+        assert!(reader.withdraw_in_progress);
+        assert_eq!(withdraw_setup, withdraw);
+    }
+
+    /// Calls the encode_relaytokens and initiates the withdrawal process from xdai chain to an external address. Does not however unlock the funds on the eth side.
+    /// Refer to test_xdai_unlock_withdraw() to check unlocking funds
+    #[test]
+    #[ignore]
+    fn test_xdai_transfer_withdraw() {
+        let pk = PrivateKey::from_str(&format!(
+            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+            "632c1e54099", "51b0281"
+        ))
+        .unwrap();
+
+        let bridge = TokenBridge::new(
+            default_bridge_addresses(),
+            pk.to_address(),
+            pk,
+            "https://eth.altheamesh.com".into(),
+            "https://dai.altheamesh.com".into(),
+            TIMEOUT,
+        );
+
+        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+        let address = Address::parse_and_validate(address);
+        if address.is_err() {
+            panic!("withdraw address is wrong");
+        }
+        let to = address.unwrap();
+        //10 xdai
+        let amount = 10000000000000000000_u128;
+
+        //Run the withdrawal process
+        let runner = actix_async::System::new();
+        runner.block_on(async move {
+            //do encode relay token call with our token bridge
+            let res = encode_relaytokens(bridge, to, amount.into(), Duration::from_secs(600)).await;
+            match res {
+                Ok(_) => println!("withdraw successful to address {}", to),
+                Err(e) => panic!("Error during withdraw: {}", e),
+            }
+        })
+    }
+
+    /// This tests the the funds that were initially transfered by test_xdai_transfer_withdraw can we unlocked, Note that the event you are trying to unlock
+    /// needs to be within 40k blocks of the current xdai chain block height, or the withdraw event will not be found.
+    #[test]
+    #[ignore]
+    fn test_xdai_unlock_withdraw() {
+        let pk = PrivateKey::from_str(&format!(
+            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+            "632c1e54099", "51b0281"
+        ))
+        .unwrap();
+
+        let bridge = TokenBridge::new(
+            default_bridge_addresses(),
+            pk.to_address(),
+            pk,
+            "https://eth.altheamesh.com".into(),
+            "https://dai.altheamesh.com".into(),
+            TIMEOUT,
+        );
+
+        let runner = actix_async::System::new();
+
+        runner.block_on(async move {
+            match simulated_withdrawal_on_eth(&bridge).await {
+                Ok(()) => {
+                    println!(
+                        "Checking for withdraw events related to us (address: {})",
+                        bridge.own_address
+                    );
+                }
+                Err(e) => {
+                    println!("Received error when trying to unlock funds: {}", e);
+                }
+            }
+        })
+    }
+
+    /// This tests the function simulate_signature_submission(), which is used to tests if a transaction needs to be unlocked on eth side or not.
+    /// This function not currently in use and we instead use check_relayed_message because of simplicity, but simulate_signature_submission() is also functional and
+    /// checks the same thing as check_relayed_message() does.
+    #[test]
+    #[ignore]
+    fn test_simulate_unlock_funds() {
+        let pk = PrivateKey::from_str(&format!(
+            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+            "632c1e54099", "51b0281"
+        ))
+        .unwrap();
+
+        let bridge = TokenBridge::new(
+            default_bridge_addresses(),
+            pk.to_address(),
+            pk,
+            "https://eth.altheamesh.com".into(),
+            "https://dai.altheamesh.com".into(),
+            TIMEOUT,
+        );
+
+        let address = "0x9CAFD25b8b5982F1edA0691DEF8997C55a4d8188";
+        let address = Address::parse_and_validate(address).unwrap();
+
+        let tx_hash = "0xf75cd74e3643bb0d17780589e0f18840c89ff77532f5ac38fbff885468091620";
+        let tx_hash = Uint256::from_str(tx_hash).unwrap();
+
+        let amount = 10000000000000000000_u128;
+
+        let runner = actix_async::System::new();
+
+        runner.block_on(async move {
+            let withdraw_info = get_relay_message_hash(
+                bridge.own_address,
+                bridge.xdai_web3.clone(),
+                bridge.helper_on_xdai,
+                address,
+                tx_hash,
+                amount.into(),
+            )
+            .await
+            .unwrap();
+
+            match simulate_signature_submission(&bridge, &withdraw_info).await {
+                Ok(_) => println!("Successful simulation"),
+                Err(e) => println!("Simulation failed {}", e),
+            }
+        })
+    }
+
+    /// Tests that funds in dai are being transfered over to the xdai blockchain as long as dai funds are greater than
+    /// minimum amount to exchange (cost of a withdrawal + cost of swap to dai + cost of transfer)
+    #[test]
+    #[ignore]
+    fn test_transfer_dai() {
+        let pk = PrivateKey::from_str(&format!(
+            "983aa7cb3e22b5aa8425facb9703a{}e04bd829e675b{}e5df",
+            "632c1e54099", "51b0281"
+        ))
+        .unwrap();
+
+        let bridge = TokenBridge::new(
+            default_bridge_addresses(),
+            pk.to_address(),
+            pk,
+            "https://eth.altheamesh.com".into(),
+            "https://dai.altheamesh.com".into(),
+            TIMEOUT,
+        );
+
+        let runner = actix_async::System::new();
+        runner.block_on(async move {
+            let res = transfer_dai(bridge.clone(), bridge.get_dai_balance().await.unwrap()).await;
+            if res.is_err() {
+                panic!("Failed to rescue dai with {:?}", res);
+            }
+        })
+    }
+}

--- a/rita_common/src/token_bridge/xdai_bridge.rs
+++ b/rita_common/src/token_bridge/xdai_bridge.rs
@@ -1,0 +1,264 @@
+use crate::token_bridge::*;
+use auto_bridge::check_relayed_message;
+use auto_bridge::get_payload_for_funds_unlock;
+use auto_bridge::get_usdt_address;
+use auto_bridge::HelperWithdrawInfo;
+use auto_bridge::MINIMUM_DAI_TO_SEND;
+use auto_bridge::MINIMUM_USDC_TO_CONVERT;
+use auto_bridge::{check_withdrawals, get_relay_message_hash};
+use auto_bridge::{TokenBridge as TokenBridgeCore, TokenBridgeError};
+use clarity::utils::display_uint256_as_address;
+use futures::future::join3;
+use num256::Uint256;
+use rand::{thread_rng, Rng};
+use std::collections::HashSet;
+use web30::amm::DAI_CONTRACT_ADDRESS;
+use web30::amm::USDC_CONTRACT_ADDRESS;
+use web30::jsonrpc::error::Web3Error;
+
+/// Transfers dai present in eth address from previous xdai_bridge iterations to the xdai chain.
+/// This also assists in rescuing any stranded dai balance because of failures in depositing flow.
+pub async fn transfer_dai(
+    bridge: TokenBridgeCore,
+    dai_balance: Uint256,
+) -> Result<(), TokenBridgeError> {
+    info!("Our DAI balance is {}, sending to xDai!", dai_balance);
+    detailed_state_change(DetailedBridgeState::DaiToXdai {
+        amount: dai_balance.clone(),
+    });
+
+    // Remove up to U16_MAX wei from this transaction, this is well under a cent.
+    // what this does is randomly change the tx hash and help prevent 'stuck' transactions
+    // thanks to anti-spam mechanisms. Payments get this 'for free' thanks to changing debts
+    // numbers. And other tx's here do thanks to changing exchange rates and other external factors
+    // this is the only transaction that will be exactly the same for a very long period.
+    let mut rng = thread_rng();
+    let some_wei: u16 = rng.gen();
+    let amount = dai_balance - Uint256::from(some_wei);
+
+    // Over the bridge into xDai
+    bridge
+        .dai_to_xdai_bridge(amount, ETH_TRANSFER_TIMEOUT)
+        .await?;
+    Ok(())
+}
+
+/// Processes the withdrawing state, returns true if any action was taken
+pub async fn process_withdraws(bridge: &TokenBridgeCore) -> bool {
+    let mut writer = get_bridge_state();
+    if writer.withdraw_in_progress {
+        let withdraw_details = match &writer.withdraw_details {
+            Some(a) => a.clone(),
+            None => {
+                error!("No withdraw information present");
+                writer.withdraw_in_progress = false;
+                set_bridge_state(writer.clone());
+                return false;
+            }
+        };
+        let amount = withdraw_details.amount.clone();
+        let address = withdraw_details.to;
+        match withdraw(withdraw_details).await {
+            Ok(_) => {
+                info!(
+                    "Initiating withdrawal of amount {} to address {}",
+                    amount, address
+                );
+            }
+            Err(e) => error!("Received an error when initiating a withdrawal: {}", e),
+        };
+
+        //reset the withdraw lock
+        writer.withdraw_in_progress = false;
+        writer.withdraw_details = None;
+        set_bridge_state(writer);
+        return true;
+    }
+    // check for withdrawal events and execute them, this always runs so that it catches
+    // any waiting withdraw events for this router
+    match simulated_withdrawal_on_eth(bridge).await {
+        Ok(()) => {
+            info!(
+                "Checking for withdraw events related to us (address: {})",
+                bridge.own_address
+            );
+        }
+        Err(e) => {
+            info!("Received error when trying to unlock funds: {}", e);
+        }
+    }
+    false
+}
+
+/// The logic for the Eth -> Xdai bridge operation that runs every tick that also handles withdrawals.
+/// We start by checking the lazy static lock to check for any new withdrawals that were requested.
+/// If we find one, we initiate this withdrawal and reset the lock. Next we loop through events
+/// on the xdai blockchain to find any withdrawals related to us, and if so we unlock these funds.
+/// We then rescue any stuck dai and send any eth that we have over to the xdai chain.
+pub async fn xdai_bridge(bridge: TokenBridgeCore) {
+    let (our_dai_balance, our_usdc_balance, our_usdt_balance) = join3(
+        bridge.get_usdc_balance(),
+        bridge.get_dai_balance(),
+        bridge.get_usdt_balance(),
+    )
+    .await;
+    let our_dai_balance = match our_dai_balance {
+        Ok(val) => val,
+        Err(e) => {
+            warn!("Failed to get our dai balance with {}", e);
+            return;
+        }
+    };
+    let our_usdc_balance = match our_usdc_balance {
+        Ok(val) => val,
+        Err(e) => {
+            warn!("Failed to get our usdc balance with {}", e);
+            return;
+        }
+    };
+    let our_usdt_balance = match our_usdt_balance {
+        Ok(val) => val,
+        Err(e) => {
+            warn!("Failed to get our usdt balance with {}", e);
+            return;
+        }
+    };
+
+    // process withdraws, if any are processed be done for this iteration
+    if process_withdraws(&bridge).await {
+        return;
+    }
+
+    let mut token_to_swap = None;
+    if our_usdc_balance >= MINIMUM_USDC_TO_CONVERT.into() {
+        token_to_swap = Some(*USDC_CONTRACT_ADDRESS);
+    } else if our_usdt_balance >= MINIMUM_USDC_TO_CONVERT.into() {
+        token_to_swap = Some(get_usdt_address());
+    }
+
+    if let Some(token) = token_to_swap {
+        let res = bridge
+            .eth_web3
+            .swap_uniswap_v3(
+                bridge.eth_privatekey,
+                token,
+                *DAI_CONTRACT_ADDRESS,
+                None,
+                our_dai_balance,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(ETH_TRANSFER_TIMEOUT),
+            )
+            .await;
+        info!(
+            "Swap from {} to dai on uniswap returned with {:?}",
+            get_usdt_address(),
+            res
+        );
+        detailed_state_change(DetailedBridgeState::Swap);
+        return;
+    }
+
+    if our_dai_balance >= MINIMUM_DAI_TO_SEND.into() {
+        // transfer dai exchanged from eth during previous iterations
+        let res = transfer_dai(bridge.clone(), our_dai_balance).await;
+        info!("DAI send to xdai returned with {:?}", res);
+        return;
+    }
+
+    detailed_state_change(DetailedBridgeState::NoOp);
+}
+
+/// This function is called inside the bridge loop. It retrieves the 'n' most recent blocks
+/// (where 'n' is the const 'BLOCKS' that is currently set to 40,032, which represents 1 week of blocks on xdai chain) that
+/// have withdraw events related to our address. It then simulates these events and submits
+/// the signatures needed to unlock the funds.
+pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(), TokenBridgeError> {
+    let client = bridge.xdai_web3.clone();
+    let mut h = HashSet::new();
+    h.insert(bridge.own_address);
+
+    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h).await?;
+
+    for event in events.iter() {
+        let txid = event.txid.clone();
+        let amount = event.amount.clone();
+
+        let withdraw_info = get_relay_message_hash(
+            bridge.own_address,
+            bridge.xdai_web3.clone(),
+            bridge.helper_on_xdai,
+            event.receiver,
+            txid.clone(),
+            amount.clone(),
+        )
+        .await?;
+
+        // check if the event has already unlocked the funds or not
+        let res = match check_relayed_message(
+            event.txid.clone(),
+            bridge.eth_web3.clone(),
+            bridge.own_address,
+            bridge.xdai_bridge_on_eth,
+        )
+        .await
+        {
+            Ok(a) => a,
+            Err(e) => {
+                error!(
+                    "Received Error when checking for signature 'relayedMessages': {}, skipping",
+                    e
+                );
+                continue;
+            }
+        };
+
+        if res {
+            trace!(
+                "Transaction with Id: {} has already been unlocked, skipping",
+                display_uint256_as_address(txid.clone())
+            );
+            continue;
+        } else {
+            //unlock this transaction
+            trace!(
+                "Tx Hash is {} with the amount of {} for a withdraw event",
+                display_uint256_as_address(txid.clone()),
+                amount
+            );
+            let _res = bridge
+                .submit_signatures_to_unlock_funds(withdraw_info, SIGNATURES_TIMEOUT)
+                .await?;
+            detailed_state_change(DetailedBridgeState::DaiToDest {
+                amount_of_dai: amount,
+                dest_address: event.receiver,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// This function simulates the withdraw event given to it. Based on this information, we can decide if we want to
+/// process this transaction by using real money. This allows us to unlock the funds on the 'eth' side. This function is currently not in use
+/// and we use check_relayed_message() instead for simplicity.
+#[allow(dead_code)]
+pub async fn simulate_signature_submission(
+    bridge: &TokenBridgeCore,
+    data: &HelperWithdrawInfo,
+) -> Result<Vec<u8>, Web3Error> {
+    let payload = get_payload_for_funds_unlock(data);
+    bridge
+        .eth_web3
+        .simulate_transaction(
+            bridge.xdai_bridge_on_eth,
+            0_u32.into(),
+            payload,
+            bridge.own_address,
+            None,
+        )
+        .await
+}

--- a/rita_common/src/tunnel_manager/contact_peers.rs
+++ b/rita_common/src/tunnel_manager/contact_peers.rs
@@ -29,10 +29,10 @@ pub async fn tm_neighbor_inquiry_hostname(their_hostname: String) -> Result<(), 
 
     // note this may block and should only be called in the peer discovery loop where blocking is accounted for
     // note we add the hello port to make this a valid socket address which must include one, any port could be used here
-    let res = format!("{}:{}", their_hostname, rita_hello_port).to_socket_addrs();
+    let res = format!("{their_hostname}:{rita_hello_port}").to_socket_addrs();
     match res {
         Ok(dnsresult) => {
-            let url = format!("http://[{}]:{}/hello", their_hostname, rita_hello_port);
+            let url = format!("http://[{their_hostname}]:{rita_hello_port}/hello");
             info!("Saying hostname hello to: {:?} at ip {:?}", url, dnsresult);
             if dnsresult.clone().next().is_some() && is_gateway {
                 // dns records may have many ip's if we get multiple it's a load

--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -54,7 +54,7 @@ pub enum TunnelAction {
 
 impl fmt::Display for TunnelAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -71,7 +71,7 @@ pub enum PaymentState {
 
 impl fmt::Display for PaymentState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rita_common/src/usage_tracker/mod.rs
+++ b/rita_common/src/usage_tracker/mod.rs
@@ -89,7 +89,7 @@ fn to_formatted_payment_tx(input: PaymentTx) -> FormattedPaymentTx {
             to: input.to,
             from: input.from,
             amount: input.amount,
-            txid: format!("{:#066x}", txid),
+            txid: format!("{txid:#066x}"),
         },
         None => FormattedPaymentTx {
             to: input.to,

--- a/rita_exit/src/database/database_tools.rs
+++ b/rita_exit/src/database/database_tools.rs
@@ -165,10 +165,8 @@ pub fn get_client(
     match filtered_list.load::<models::Client>(conn) {
         Ok(entry) => {
             if entry.len() > 1 {
-                let err_msg = format!(
-                    "More than one exact match with wg: {} eth: {} ip: {}",
-                    wg, key, ip
-                );
+                let err_msg =
+                    format!("More than one exact match with wg: {wg} eth: {key} ip: {ip}");
                 error!("{}", err_msg);
                 panic!("{}", err_msg);
             } else if entry.is_empty() {
@@ -642,8 +640,7 @@ pub fn get_client_subnet(
                 Ok(a) => Some(a),
                 Err(e) => {
                     return Err(Box::new(RitaExitError::MiscStringError(format!(
-                        "Unable to assign user ipv6 subnet when parsing latest index: {}",
-                        e
+                        "Unable to assign user ipv6 subnet when parsing latest index: {e}"
                     ))));
                 }
             }
@@ -661,8 +658,7 @@ pub fn get_client_subnet(
                 Ok(a) => Some(a),
                 Err(e) => {
                     return Err(Box::new(RitaExitError::MiscStringError(format!(
-                        "Unable to assign user ipv6 subnet: {}",
-                        e
+                        "Unable to assign user ipv6 subnet: {e}"
                     ))));
                 }
             }
@@ -677,8 +673,7 @@ pub fn get_client_subnet(
             Ok(a) => a,
             Err(e) => {
                 return Err(Box::new(RitaExitError::MiscStringError(format!(
-                    "Unable to assign user ipv6 subnet when parsing iterative index: {}",
-                    e
+                    "Unable to assign user ipv6 subnet when parsing iterative index: {e}"
                 ))));
             }
         });
@@ -713,8 +708,7 @@ pub fn get_client_subnet(
             } else {
                 error!("Chosen subnet: {:?} is in use! Race condition hit", addr);
                 Err(Box::new(RitaExitError::MiscStringError(format!(
-                    "Unable to assign user ipv6 subnet. Chosen subnet {:?} is in use",
-                    addr
+                    "Unable to assign user ipv6 subnet. Chosen subnet {addr:?} is in use"
                 ))))
             }
         }
@@ -768,8 +762,7 @@ fn generate_iterative_client_subnet(
             Ok(a) => a,
             Err(e) => {
                 return Err(Box::new(RitaExitError::MiscStringError(format!(
-                    "Unable to parse a valid client subnet: {:?}",
-                    e
+                    "Unable to parse a valid client subnet: {e:?}"
                 ))))
             }
         });
@@ -1025,13 +1018,13 @@ mod tests {
         let str2 = "2";
         let str3 = "1,2,5,10,92";
         let vec = str.rsplit_once(',');
-        println!("{:?}", vec);
+        println!("{vec:?}");
 
         let vec = str2.rsplit_once(',');
-        println!("{:?}", vec);
+        println!("{vec:?}");
 
         let vec = str3.rsplit_once(',');
-        println!("{:?}", vec);
+        println!("{vec:?}");
     }
 
     #[test]
@@ -1039,9 +1032,9 @@ mod tests {
         let sub: IpNetwork = "fd00::1000/124".parse().unwrap();
 
         let net = sub.network();
-        println!("net: {:?}", net);
+        println!("net: {net:?}");
         let size = sub.size();
-        println!("size: {:?}", size);
+        println!("size: {size:?}");
 
         let exit_sub: IpNetwork = "fd00::1000/120".parse().unwrap();
         let sub: IpNetwork = "fd00::1060/124".parse().unwrap();
@@ -1077,7 +1070,7 @@ mod tests {
         if let Some(mut list_str) = client_ipv6_list {
             if !list_str.is_empty() {
                 let list: Vec<&str> = list_str.split(',').collect();
-                println!("List looks like: {:?}", list);
+                println!("List looks like: {list:?}");
                 for ipv6_str in list {
                     let ipv6_sub: IpNetwork =
                         ipv6_str.parse().expect("Unable to parse ipnetwork subnet");
@@ -1092,7 +1085,7 @@ mod tests {
                 let mut new_str = ",".to_owned();
                 new_str.push_str(&internet_ip.to_string());
                 list_str.push_str(&new_str);
-                println!("list_str looks like: {:?}", list_str);
+                println!("list_str looks like: {list_str:?}");
                 println!("hit test case 2");
             } else {
                 // List is empty
@@ -1192,7 +1185,7 @@ mod tests {
                 let c_net: IpNetwork = client_ip.parse().expect("Unable to parse client subnet");
                 let e_net: IpNetwork = exit_ip.parse().expect("Unable to parse exit subnet");
                 if e_net.contains(c_net.ip()) {
-                    println!("reclaiming client {:?} to exit sub {:?}", c_net, e_net);
+                    println!("reclaiming client {c_net:?} to exit sub {e_net:?}");
 
                     // After we reclaim an index, we break from the loop. The prevents duplicate reclaiming when two instances have the same subnet
                     break;
@@ -1208,11 +1201,11 @@ mod tests {
             "2000:fbad:10:1450::/60".parse().unwrap(),
         );
 
-        println!("{:?}", a);
+        println!("{a:?}");
 
         let client_ipv6 = "2602:fbad:0:2340::/60,2602:fbad:10:2500::/60";
         let client_sub: Vec<&str> = client_ipv6.split(',').collect();
-        println!("{:?}", client_sub);
+        println!("{client_sub:?}");
         let exit_sub = vec![
             "2602:fbad:10::/45".to_string(),
             "2602:fbad::/45".to_string(),

--- a/rita_exit/src/database/geoip.rs
+++ b/rita_exit/src/database/geoip.rs
@@ -46,14 +46,12 @@ pub fn get_gateway_ip_single(mesh_ip: IpAddr) -> Result<IpAddr, Box<RitaExitErro
                     }
                 }
                 Err(e) => Err(Box::new(RitaExitError::MiscStringError(format!(
-                    "Parse routes babel monitor error, {:?}",
-                    e
+                    "Parse routes babel monitor error, {e:?}"
                 )))),
             }
         }
         Err(e) => Err(Box::new(RitaExitError::MiscStringError(format!(
-            "Error opening babel stream, {:?}",
-            e
+            "Error opening babel stream, {e:?}"
         )))),
     }
 }
@@ -185,7 +183,7 @@ pub fn get_country(ip: IpAddr) -> Result<String, Box<RitaExitError>> {
     match cache_result {
         Some(code) => Ok(code),
         None => {
-            let geo_ip_url = format!("https://geoip.maxmind.com/geoip/v2.1/country/{}", ip);
+            let geo_ip_url = format!("https://geoip.maxmind.com/geoip/v2.1/country/{ip}");
             info!(
                 "making GeoIP request to {} for {}",
                 geo_ip_url,

--- a/rita_exit/src/database/sms.rs
+++ b/rita_exit/src/database/sms.rs
@@ -44,8 +44,7 @@ async fn check_text(number: String, code: String, api_key: String) -> Result<boo
         Ok(a) => a,
         Err(e) => {
             return Err(RitaExitError::MiscStringError(format!(
-                "Send request error: {:?}",
-                e
+                "Send request error: {e:?}"
             )))
         }
     };
@@ -84,8 +83,7 @@ async fn send_text(number: String, api_key: String) -> Result<(), RitaExitError>
     {
         Ok(_a) => Ok(()),
         Err(e) => Err(RitaExitError::MiscStringError(format!(
-            "Send text error: {:?}",
-            e
+            "Send text error: {e:?}"
         ))),
     }
 }

--- a/rita_exit/src/database/struct_tools.rs
+++ b/rita_exit/src/database/struct_tools.rs
@@ -90,7 +90,7 @@ pub fn texts_sent(client: &models::Client) -> i32 {
 pub fn display_hashset(input: &HashSet<String>) -> String {
     let mut out = String::new();
     for item in input.iter() {
-        write!(out, "{}, ", item).unwrap();
+        write!(out, "{item}, ").unwrap();
     }
     out
 }
@@ -120,7 +120,7 @@ pub fn client_to_new_db_client(
         email: client.reg_details.email.clone().unwrap_or_default(),
         phone: client.reg_details.phone.clone().unwrap_or_default(),
         country,
-        email_code: format!("{:06}", rand_code),
+        email_code: format!("{rand_code:06}"),
         text_sent: 0,
         verified: false,
         email_sent_time: 0,

--- a/rita_exit/src/error.rs
+++ b/rita_exit/src/error.rs
@@ -98,21 +98,21 @@ impl From<BabelMonitorError> for RitaExitError {
 impl Display for RitaExitError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            RitaExitError::MiscStringError(a) => write!(f, "{}", a,),
-            RitaExitError::EmailNotFound(a) => write!(f, "Could not find email for {:?}", a),
-            RitaExitError::AddrParseError(a) => write!(f, "{:?}", a,),
-            RitaExitError::IpAddrError(a) => write!(f, "No route found for mesh ip: {:?}", a,),
-            RitaExitError::DieselError(a) => write!(f, "{}", a,),
-            RitaExitError::RitaCommonError(a) => write!(f, "{}", a,),
-            RitaExitError::RenderError(a) => write!(f, "{}", a,),
-            RitaExitError::EmailError(a) => write!(f, "{}", a,),
-            RitaExitError::FileError(a) => write!(f, "{}", a,),
-            RitaExitError::SmtpError(a) => write!(f, "{}", a,),
-            RitaExitError::IpNetworkError(a) => write!(f, "{}", a,),
-            RitaExitError::PhoneParseError(a) => write!(f, "{}", a,),
-            RitaExitError::ClarityError(a) => write!(f, "{}", a,),
-            RitaExitError::AltheaTypesError(a) => write!(f, "{}", a,),
-            RitaExitError::KernelInterfaceError(a) => write!(f, "{}", a,),
+            RitaExitError::MiscStringError(a) => write!(f, "{a}",),
+            RitaExitError::EmailNotFound(a) => write!(f, "Could not find email for {a:?}"),
+            RitaExitError::AddrParseError(a) => write!(f, "{a:?}",),
+            RitaExitError::IpAddrError(a) => write!(f, "No route found for mesh ip: {a:?}",),
+            RitaExitError::DieselError(a) => write!(f, "{a}",),
+            RitaExitError::RitaCommonError(a) => write!(f, "{a}",),
+            RitaExitError::RenderError(a) => write!(f, "{a}",),
+            RitaExitError::EmailError(a) => write!(f, "{a}",),
+            RitaExitError::FileError(a) => write!(f, "{a}",),
+            RitaExitError::SmtpError(a) => write!(f, "{a}",),
+            RitaExitError::IpNetworkError(a) => write!(f, "{a}",),
+            RitaExitError::PhoneParseError(a) => write!(f, "{a}",),
+            RitaExitError::ClarityError(a) => write!(f, "{a}",),
+            RitaExitError::AltheaTypesError(a) => write!(f, "{a}",),
+            RitaExitError::KernelInterfaceError(a) => write!(f, "{a}",),
         }
     }
 }

--- a/rita_exit/src/lib.rs
+++ b/rita_exit/src/lib.rs
@@ -121,9 +121,8 @@ Options:
     -c, --config=<settings>   Name of config file
     --future                    Enable B side of A/B releases
 About:
-    Version {} - {}
-    git hash {}",
-        READABLE_VERSION, version, git_hash
+    Version {READABLE_VERSION} - {version}
+    git hash {git_hash}"
     )
 }
 

--- a/rita_exit/src/network_endpoints/mod.rs
+++ b/rita_exit/src/network_endpoints/mod.rs
@@ -147,8 +147,7 @@ pub async fn secure_setup_request(
                 their_wg_pubkey,
             );
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!(
-                "Error in exit setup for {} malformed packet header!",
-                their_wg_pubkey
+                "Error in exit setup for {their_wg_pubkey} malformed packet header!"
             ));
         }
     };
@@ -168,7 +167,7 @@ pub async fn secure_setup_request(
             Err(e) => {
                 error!("Signup client failed with {:?}", e);
                 HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                    .json(format!("Signup client failed with {:?}", e))
+                    .json(format!("Signup client failed with {e:?}"))
             }
         }
     } else {
@@ -202,7 +201,7 @@ pub async fn secure_status_request(request: Json<EncryptedExitClientIdentity>) -
         Ok(conn) => conn,
         Err(e) => {
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
-                .json(format!("Error getting database connection: {:?}", e))
+                .json(format!("Error getting database connection: {e:?}"))
         }
     };
     let state = match client_status(decrypted_id, &conn) {
@@ -213,8 +212,7 @@ pub async fn secure_status_request(request: Json<EncryptedExitClientIdentity>) -
                 their_wg_pubkey, e
             );
             return HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).json(format!(
-                "Internal error in client status for {} with {:?}",
-                their_wg_pubkey, e
+                "Internal error in client status for {their_wg_pubkey} with {e:?}"
             ));
         }
     };

--- a/rita_exit/src/rita_loop/mod.rs
+++ b/rita_exit/src/rita_loop/mod.rs
@@ -153,8 +153,7 @@ fn rita_exit_loop(
             if !*successful_setup {
                 let db_uri = settings::get_rita_exit().db_uri;
                 let message = format!(
-                    "Failed to get database connection to {} on first setup loop, the exit can not operate without the ability to get the clients list from the database exiting",
-                    db_uri
+                    "Failed to get database connection to {db_uri} on first setup loop, the exit can not operate without the ability to get the clients list from the database exiting"
                 );
                 error!("{}", message);
                 let sys = AsyncSystem::current();

--- a/rita_exit/src/traffic_watcher/mod.rs
+++ b/rita_exit/src/traffic_watcher/mod.rs
@@ -339,5 +339,5 @@ fn test_merge_counters() {
     ret.extend(map1);
     ret.extend(map2);
 
-    println!("{:?}", ret);
+    println!("{ret:?}");
 }

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -25,7 +25,7 @@ pub fn default_save_interval() -> u64 {
 }
 
 pub fn default_config_path() -> String {
-    format!("/etc/{}.toml", APP_NAME)
+    format!("/etc/{APP_NAME}.toml")
 }
 
 /// This struct represents an exit server cluster, meaning

--- a/settings/src/error.rs
+++ b/settings/src/error.rs
@@ -41,11 +41,11 @@ impl From<serde_json::Error> for SettingsError {
 impl Display for SettingsError {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            SettingsError::TomlSeError(e) => write!(f, "{}", e),
-            SettingsError::TomlDeError(e) => write!(f, "{}", e),
-            SettingsError::IOError(e) => write!(f, "{}", e),
-            SettingsError::IpNetworkError(e) => write!(f, "{}", e),
-            SettingsError::SerdeJsonError(e) => write!(f, "{}", e),
+            SettingsError::TomlSeError(e) => write!(f, "{e}"),
+            SettingsError::TomlDeError(e) => write!(f, "{e}"),
+            SettingsError::IOError(e) => write!(f, "{e}"),
+            SettingsError::IpNetworkError(e) => write!(f, "{e}"),
+            SettingsError::SerdeJsonError(e) => write!(f, "{e}"),
         }
     }
 }

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -346,7 +346,7 @@ pub fn check_if_exit() -> bool {
 /// This merges 2 json objects, overwriting conflicting values in `a`
 pub fn json_merge(a: &mut Value, b: &Value) {
     match (a, b) {
-        (&mut Value::Object(ref mut a), &Value::Object(ref b)) => {
+        (&mut Value::Object(ref mut a), Value::Object(b)) => {
             for (k, v) in b {
                 json_merge(a.entry(k.clone()).or_insert(Value::Null), v);
             }
@@ -365,7 +365,7 @@ fn get_settings_file_from_ns() -> String {
         Ok(s) => s,
         Err(_) => panic!("Could not get netns name!"),
     };
-    let settings_file = format!("/var/tmp/settings_{}", ns);
+    let settings_file = format!("/var/tmp/settings_{ns}");
     settings_file
 }
 
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn test_settings_test() {
         let ret = RitaClientSettings::new("test.toml").unwrap();
-        println!("{:?}", ret);
+        println!("{ret:?}");
     }
 
     #[test]

--- a/test_runner/build.rs
+++ b/test_runner/build.rs
@@ -7,5 +7,5 @@ fn main() {
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .unwrap_or_else(|| "(unknown)".to_string());
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }


### PR DESCRIPTION
 Revamp the token bridge module

This patch updates the token bridge module and changes how it works in
several ways

1) No more support for sending ETH directly, gas management caused the
   majority of the complexity in this module and also frustration for
   end users, who expect to get their total value into the router. In
   order to address this we will be sending ETH to routers to pay the
   fees. So no more ETH management is required.
2) Module refactor splitting what was previously one file into three to
   help with readability and make room for an upcoming Alhtea blockchain
   module

This will require an update to the dashboard as extensive changes to the
display states have also been made. But we're now envisoning a deposit
situation where the user does not really look at the router. So detailed
display isn't as high on our list of priorities.


This pr also contains an especially large clippy run so you may want to review each commit individually. 