### PR TITLE
fix wire_enabled bug

### DIFF
--- a/rita_client/src/dashboard/mod.rs
+++ b/rita_client/src/dashboard/mod.rs
@@ -83,6 +83,7 @@ pub fn start_client_dashboard(rita_dashboard_port: u16) {
                     .route("/operator/{address}", web::post().to(change_operator))
                     .route("/operator/remove", web::post().to(remove_operator))
                     .route("/operator_fee", web::get().to(get_operator_fee))
+                    .route("/operator_fee/{fee}", web::post().to(set_operator_fee))
                     .route("/operator_debt", web::get().to(get_operator_debt))
                     .route("/debts", web::get().to(get_debts))
                     .route("/debts/reset", web::post().to(reset_debt))

--- a/rita_client/src/dashboard/prices.rs
+++ b/rita_client/src/dashboard/prices.rs
@@ -33,7 +33,7 @@ pub async fn set_auto_pricing(path: Path<bool>) -> HttpResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Prices {
     exit_dest_price: u128,
-    dao_fee: Uint256,
+    operator_fee: Uint256,
     simulated_tx_fee: u8,
 }
 
@@ -46,7 +46,7 @@ pub async fn get_prices(_req: HttpRequest) -> HttpResponse {
     let operator_fee = settings::get_rita_client().operator.operator_fee;
     let p = Prices {
         exit_dest_price,
-        dao_fee: operator_fee,
+        operator_fee,
         simulated_tx_fee,
     };
     HttpResponse::Ok().json(p)

--- a/settings/src/client.rs
+++ b/settings/src/client.rs
@@ -228,6 +228,8 @@ pub struct RitaClientSettings {
 }
 
 impl RitaClientSettings {
+    /// This is a low level fn that mutates the current settings object, but does not save it.
+    /// prefer the higher level settings::merge_config_json(new_settings), which calls this, to actually merge into memory
     pub fn merge(&mut self, changed_settings: serde_json::Value) -> Result<(), SettingsError> {
         let mut settings_value = serde_json::to_value(self.clone())?;
 

--- a/settings/src/localization.rs
+++ b/settings/src/localization.rs
@@ -1,7 +1,7 @@
 use phonenumber::PhoneNumber;
 
 fn default_wyre_enabled() -> bool {
-    true
+    false
 }
 
 fn default_display_currency_symbol() -> bool {


### PR DESCRIPTION
The value was lost in translation when converting from the Op Tools response to the local settings.  The merge_settings_safely fn was previously just dropping the new values.  It now actually merges them into settings which are then saved to memory later.