### PR TITLE
Force xdai_bridge to use better uniswap pools

### DIFF
--- a/rita_common/src/token_bridge/xdai_bridge.rs
+++ b/rita_common/src/token_bridge/xdai_bridge.rs
@@ -150,7 +150,7 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
                 bridge.eth_privatekey,
                 token,
                 *DAI_CONTRACT_ADDRESS,
-                None,
+                Some(100u16.into()),
                 token_amount.clone(),
                 None,
                 Some(get_min_amount_out(token_amount)),


### PR DESCRIPTION
Without a preferred fee value passed in to web3.swap_uniswap_v3(), the 0.3% fee pool will be used for any token swap. When it comes to stablecoin swaps the 0.3% pool typically has low liquidity (bad rates)
and is vulnerable to "sandwich attacks". By specifying the 0.01% pool instead we are likely to get the best rates and avoid many attacks due to very high liquidity needed to perform the sandwich attack.