### PR TITLE
Stabilize integration test routes

### DIFF
--- a/test_runner/src/tests.rs
+++ b/test_runner/src/tests.rs
@@ -1,3 +1,4 @@
+use core::time;
 use std::{
     collections::HashMap,
     convert::TryInto,
@@ -8,9 +9,8 @@ use std::{
 };
 
 use althea_kernel_interface::{KernelInterfaceError, KI};
-use babel_monitor::{open_babel_stream, parse_routes};
+use babel_monitor::{open_babel_stream, parse_routes, structs::Route};
 use ipnetwork::IpNetwork;
-use log::info;
 use nix::{
     fcntl::{open, OFlag},
     sched::{setns, CloneFlags},
@@ -73,37 +73,94 @@ pub fn test_routes(nsinfo: NamespaceInfo, expected: HashMap<Namespace, RouteHop>
         routesmap = rita_handler.join().unwrap();
     }
     let mut count = 0;
+    let mut not_found: Vec<(Namespace, Namespace)> = Vec::new();
     for ns1 in nsinfo.clone().names {
         'neighs: for ns2 in &nsinfo.names {
             if &ns1 == ns2 {
                 continue;
             }
-            info!("finding route for {:?}, {:?}", ns1.name, ns2.name);
 
             let routes = routesmap.get(&ns1.name).unwrap();
             //within routes there must be a route that matches the expected price between the dest (fd00::id) and the expected next hop (fe80::id)
 
-            let expected_data = expected.get(&ns1).unwrap().destination.get(ns2).unwrap();
-            let expected_cost = expected_data.clone().0;
-            let expected_hop_id: u16 = expected_data.clone().1.id.try_into().unwrap();
-            let ns2_id: u16 = ns2.id.try_into().unwrap();
-            let neigh_ip = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, expected_hop_id));
-            let dest_ip = IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, ns2_id));
-            for r in routes {
-                if let IpNetwork::V6(ref ip) = r.prefix {
-                    if ip.ip() == dest_ip
-                        && r.price == expected_cost
-                        && r.fee == ns1.cost
-                        && r.neigh_ip == neigh_ip
-                    {
-                        println!("We found route for {:?}, {:?}: {:?}", ns1.name, ns2.name, r);
-                        count += 1;
-                        continue 'neighs;
-                    }
-                }
+            if try_route(&expected, routes, ns1.clone(), ns2.clone()) {
+                println!("We found route for {:?}, {:?}", ns1.name, ns2.name);
+                count += 1;
+                continue 'neighs;
+            } else {
+                println!(
+                    "No route found for {:?}, {:?}, retrying...",
+                    ns1.name, ns2.name
+                );
+                not_found.insert(0, (ns1.clone(), ns2.clone()));
             }
         }
     }
 
+    while !not_found.is_empty() {
+        let mut minutes_passed = 0;
+        let one_min = time::Duration::from_secs(60);
+        println!("Retrying failed routes");
+        let namespaces = not_found.pop().unwrap();
+        let ns1 = namespaces.clone().0;
+        let ns2 = namespaces.clone().1;
+        let routes = routesmap.get(&ns1.name).unwrap();
+
+        while minutes_passed < 10 {
+            thread::sleep(one_min);
+            minutes_passed += 1;
+            match try_route(&expected, routes, ns1.clone(), ns2.clone()) {
+                true => {
+                    println!("We found route for {:?}, {:?}", ns1.name, ns2.name);
+                    count += 1;
+                    break;
+                }
+                false => {
+                    println!(
+                        "No route found for {:?}, {:?}, retrying...",
+                        ns1.name, ns2.name
+                    );
+                }
+            }
+        }
+        if minutes_passed > 10 {
+            println!(
+                "Could not find missing routes after 10 minutes: {:?}, {:?}",
+                namespaces, not_found
+            );
+            return count;
+        }
+    }
+
     count
+}
+
+/// Look for an installed route given our expected list between ns1 and ns2
+fn try_route(
+    expected: &HashMap<Namespace, RouteHop>,
+    routes: &Vec<Route>,
+    ns1: Namespace,
+    ns2: Namespace,
+) -> bool {
+    let expected_data = expected.get(&ns1).unwrap().destination.get(&ns2).unwrap();
+    let expected_cost = expected_data.clone().0;
+    let expected_hop_id: u16 = expected_data.clone().1.id.try_into().unwrap();
+    let ns2_id: u16 = ns2.id.try_into().unwrap();
+    let neigh_ip = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, expected_hop_id));
+    let dest_ip = IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, ns2_id));
+    for r in routes {
+        if let IpNetwork::V6(ref ip) = r.prefix {
+            if ip.ip() == dest_ip
+                && r.price == expected_cost
+                && r.fee == ns1.cost
+                && r.neigh_ip == neigh_ip
+            {
+                return true;
+            } else {
+                continue;
+            }
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
Test routes now checks continually for routes that were not discovered in the first go around, up to a time limit of ten minutes. This fixes a previous problem where certain routes would not be set up at random by allowing more time to resolve route setup.