### PR TITLE
Add status requests for GotInfo

### DIFF
--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -246,7 +246,9 @@ pub fn client_status(
         })
     } else {
         error!("De-registering client! {:?}", client);
-        Ok(ExitState::New)
+        Err(Box::new(RitaExitError::MiscStringError(
+            "Status request for a client that isnt present, please register first!".to_string(),
+        )))
     }
 }
 


### PR DESCRIPTION
Whne a router is registered by Operator tools, the router should reach out to the exit whatever state it is in (New or GotInfo) and update its entry to Registered