### PR TITLE
Replace link and global v6 addr regex with proc parsing

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -89,6 +89,7 @@ pub enum KernelInterfaceError {
     InvalidArchString(String),
     FailedToGetSystemTime,
     FailedToGetSystemKernelVersion,
+    ParseError(String),
 }
 
 impl fmt::Display for KernelInterfaceError {
@@ -109,6 +110,7 @@ impl fmt::Display for KernelInterfaceError {
                 write!(f, "Failed to get load average!")
             }
             KernelInterfaceError::FailedToGetMemoryInfo => write!(f, "Failed to get memory info!"),
+            KernelInterfaceError::ParseError(val) => write!(f, "Unable to parse: {val}!"),
             KernelInterfaceError::NoAltheaReleaseFeedFound => {
                 write!(f, "Could not pares /etc/opkg/customfeeds.conf")
             }


### PR DESCRIPTION
we use /proc/net/if_inet6 to get the v6 link local and global address rather than relying on the ip command using regex. This is make this portion faster and more reliable