### PR TITLE
Fix poorly designed interface contains check

### DIFF
--- a/rita_common/src/tunnel_manager/mod.rs
+++ b/rita_common/src/tunnel_manager/mod.rs
@@ -265,7 +265,9 @@ pub fn tm_monitor_check(interface_list: &[Interface]) {
                     tun.iface_name
                 );
                 let res = tun.monitor();
-                error!("Unable to re-add tunnel to babel with: {:?}", res);
+                if let Err(e) = res {
+                    error!("Unable to re-add tunnel to babel with: {:?}", e);
+                }
             }
         }
     }


### PR DESCRIPTION
This patch updates the routine that checks if we have a wg interface for a specific wg number. Previously this routine simply took the string output of 'ip link' and checked if it contained a given wg name.

This is a terrible idea for a number of reasons, lets say you had an interface wg10 which was created and later deleted. Interface wg100 would then block the creation of a new wg10 becuase 'wg10' has a match.

This is only one of the ways this could go wrong off the top of my head.

A very simple change instead gets a list of interfaces and does a more exact string comparison.