### PR TITLE
Reduce exit routes

### DIFF
--- a/settings/src/exit.rs
+++ b/settings/src/exit.rs
@@ -54,6 +54,15 @@ pub struct ExitNetworkSettings {
     pub recompute_ipv6: bool,
     /// password that operator tools uses to verify that this is an exit
     pub pass: Option<String>,
+    /// Determines if enforcement is ensabled on the wg_exit interfaces, the htb classifier used here
+    /// is slower than we would like, and therefore overloaded exits may wish to disable enforcment
+    /// to maintain a good user experience while migrating users or waiting on a faster enforcement classifier
+    #[serde(default = "enable_enforcement_default")]
+    pub enable_enforcement: bool,
+}
+
+fn enable_enforcement_default() -> bool {
+    true
 }
 
 fn recompute_ipv6_default() -> bool {
@@ -86,6 +95,7 @@ impl ExitNetworkSettings {
             cluster_exits: Vec::new(),
             recompute_ipv6: false,
             pass: None,
+            enable_enforcement: true,
         }
     }
 }


### PR DESCRIPTION
    This patch reduces the number of exit routes installed by a factor of
    several hundred, bringing us down from 4k ipv6 routes to a much more
    manageable 27 and maintaining the full functionality.
    
    Similarly hundreds of ipv4 routes are eliminated by only assigning ipv4
    internal routes to wg_exit users and leaving the default route for the
    subnet on wg_exit_v2. Since there are only a few wg_exit users left this
    brings us from ~550 ip4 routes to ~20
    
    Also added as an option in this patch is a way to disable the root htb
    qdisc to improve routing speed temporarily.