### PR TITLE
Sync system time with last seen usage hour

### DIFF
--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -30,6 +30,7 @@ use rita_client::get_client_usage;
 use rita_client::rita_loop::start_antenna_forwarder;
 use rita_client::rita_loop::start_rita_client_loops;
 use rita_client::rita_loop::update_resolv_conf;
+use rita_client::rita_loop::update_system_time;
 use rita_client::Args;
 use rita_common::debt_keeper::save_debt_on_shutdown;
 use rita_common::logging::enable_remote_logging;
@@ -151,6 +152,7 @@ fn main() {
     start_client_dashboard(settings.network.rita_dashboard_port);
     start_antenna_forwarder(settings);
     update_resolv_conf();
+    update_system_time();
 
     if let Err(e) = system.run() {
         error!("Starting client failed with {}", e);

--- a/rita_common/src/usage_tracker/mod.rs
+++ b/rita_common/src/usage_tracker/mod.rs
@@ -474,6 +474,12 @@ pub fn get_usage_data(kind: UsageType) -> VecDeque<UsageHour> {
     }
 }
 
+/// Gets the last saved usage hour from the existing usage tracker
+pub fn get_last_saved_usage_hour() -> u64 {
+    let usage_tracker = &*(USAGE_TRACKER.read().unwrap());
+    usage_tracker.last_save_hour
+}
+
 /// Gets payment data for this router, stored on the local disk at periodic intervals
 pub fn get_payments_data() -> VecDeque<PaymentHour> {
     let usage_tracker_var = &*(USAGE_TRACKER.read().unwrap());


### PR DESCRIPTION
If the device's system time gets reset (as on startup) this will help to synchronize its time to one accurate within a couple hours which should result in wireguard handshakes being renegotiated faster.