### PR TITLE
Fix: beta19 -> beta20 upgrade exit flow

### DIFF
--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -202,6 +202,19 @@ impl dyn KernelInterface {
         }
     }
 
+    /// this function performs the teardown step of setup_indvidual_client_routes, when a router upgrades
+    /// to beta20 or later this function checks for and deltes the rules
+    pub fn teardown_individual_client_routes(&self, client_internal_ip: IpAddr) {
+        let output = self
+            .run_command("ip", &["route", "show", &client_internal_ip.to_string()])
+            .expect("Fix command");
+        let route = String::from_utf8(output.stdout).unwrap();
+        if !route.is_empty() {
+            self.run_command("ip", &["route", "del", &client_internal_ip.to_string()])
+                .expect("Fix command");
+        }
+    }
+
     /// Performs the one time startup tasks for the rita_exit clients loop
     pub fn one_time_exit_setup(
         &self,

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -546,6 +546,13 @@ pub fn setup_clients(
             );
         }
     }
+    for c_key in changed_clients_return.new_v2 {
+        if let Some(c) = key_to_client_map.get(&c_key) {
+            KI.teardown_individual_client_routes(
+                c.internal_ip.parse().expect("Invalid ipv4 in the db!"),
+            );
+        }
+    }
 
     Ok(client_states)
 }


### PR DESCRIPTION
In the recent patch 'reduce exit routes' this segment was removed as we had set a larger generic route to wg_exit_v2 removing the need for individual routes. But this change neglected to handle tearing down exiting routes when a user is upgraded.