### PR TITLE
Delete classes slectively

### DIFF
--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -93,7 +93,15 @@ impl dyn KernelInterface {
         }
 
         let stdout = &String::from_utf8(result.stdout)?;
-        Ok(stdout.contains(&format!("1:{class_id}")))
+        for line in stdout.lines() {
+            let split = line.split_ascii_whitespace();
+            for item in split {
+                if item == &format!("1:{class_id}") {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
     }
 
     /// Determines if the provided interface has a configured qdisc


### PR DESCRIPTION
This patch modifies exit behavior from clearning classes for all clients to only those that actively have classes. The class checking logic is also chnaged to be more specific and avoid potential false positives inerhent in using a very broad contains statement on a large string output.

While the ideal solution here would be to run the show command once and use the output repeatedly using a read only command will hopefully increase efficiency enough.