### PR TITLE
Use converged keys for Althea and ETH

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -63,6 +63,17 @@ impl Identity {
         }
     }
 
+    /// Returns true if this identity is converged, meaning the Althea address is
+    /// derived from and is interchangeable with the ETH address. If false we have
+    /// to avoid assumptions avoid these being the same private key
+    pub fn is_converged(&self) -> bool {
+        if let Some(althea_address) = self.althea_address {
+            althea_address.get_bytes() == self.eth_address.as_bytes()
+        } else {
+            true
+        }
+    }
+
     pub fn get_hash(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
@@ -95,9 +106,16 @@ impl Eq for Identity {}
 // Custom hash implementation that also ignores nickname
 impl Hash for Identity {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.mesh_ip.hash(state);
-        self.eth_address.hash(state);
-        self.wg_public_key.hash(state);
+        if self.is_converged() {
+            self.mesh_ip.hash(state);
+            self.eth_address.hash(state);
+            self.wg_public_key.hash(state);
+        } else {
+            self.mesh_ip.hash(state);
+            self.eth_address.hash(state);
+            self.althea_address.hash(state);
+            self.wg_public_key.hash(state);
+        }
     }
 }
 

--- a/clu/Cargo.toml
+++ b/clu/Cargo.toml
@@ -18,7 +18,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 clarity = "1.2"
 sodiumoxide = "0.2"
-deep_space = {version = "2", features = ["althea"]}
+deep_space = {version = "2.20", features = ["althea"]}
 
 [dependencies.regex]
 version = "1.5"


### PR DESCRIPTION
This dramatically simplifies a lot of operations by having the Althea key be the same public key as the Ethereum key, which we can cross derive. That way having one is equal to having the other.