### PR TITLE
Update dns servers provided by dhcp

### DIFF
--- a/althea_kernel_interface/src/manipulate_uci.rs
+++ b/althea_kernel_interface/src/manipulate_uci.rs
@@ -14,19 +14,19 @@ impl dyn KernelInterface {
         Ok(())
     }
 
-    //Sets an arbitrary UCI variable on OpenWRT
+    /// Sets an arbitrary UCI variable on OpenWRT
     pub fn set_uci_var(&self, key: &str, value: &str) -> Result<(), KernelInterfaceError> {
         self.run_uci("uci", &["set", &format!("{key}={value}")])?;
         Ok(())
     }
 
-    //Adds an arbitrary UCI variable on OpenWRT
+    /// Adds an arbitrary UCI variable on OpenWRT
     pub fn add_uci_var(&self, key: &str, value: &str) -> Result<(), KernelInterfaceError> {
         self.run_uci("uci", &["add", key, value])?;
         Ok(())
     }
 
-    //Sets an arbitrary UCI list on OpenWRT
+    /// Sets an arbitrary UCI list on OpenWRT
     pub fn set_uci_list(&self, key: &str, value: &[&str]) -> Result<(), KernelInterfaceError> {
         if let Err(e) = self.del_uci_var(key) {
             trace!("Delete uci var failed! {:?}", e);
@@ -38,13 +38,13 @@ impl dyn KernelInterface {
         Ok(())
     }
 
-    //Deletes an arbitrary UCI variable on OpenWRT
+    /// Deletes an arbitrary UCI variable on OpenWRT
     pub fn del_uci_var(&self, key: &str) -> Result<(), KernelInterfaceError> {
         self.run_uci("uci", &["delete", key])?;
         Ok(())
     }
 
-    //Retrieves the value of a given UCI path, could be one or multiple values
+    /// Retrieves the value of a given UCI path, could be one or multiple values
     pub fn get_uci_var(&self, key: &str) -> Result<String, KernelInterfaceError> {
         let output = self.run_command("uci", &["get", key])?;
         if !output.stderr.is_empty() {
@@ -57,8 +57,8 @@ impl dyn KernelInterface {
         Ok(clean_string)
     }
 
-    //Commits changes to UCI
-    pub fn uci_commit(&self, subsection: &str) -> Result<bool, KernelInterfaceError> {
+    /// Commits changes to UCI, returns true if successful
+    pub fn uci_commit(&self, subsection: &str) -> Result<(), KernelInterfaceError> {
         let output = self.run_command("uci", &["commit", subsection])?;
         if !output.status.success() {
             return Err(KernelInterfaceError::RuntimeError(format!(
@@ -66,10 +66,10 @@ impl dyn KernelInterface {
                 String::from_utf8(output.stderr)?
             )));
         }
-        Ok(true)
+        Ok(())
     }
 
-    //Resets unsaved changes to UCI
+    /// Resets unsaved changes to UCI
     pub fn uci_revert(&self, section: &str) -> Result<(), KernelInterfaceError> {
         let output = self.run_command("uci", &["revert", section])?;
         if !output.status.success() {
@@ -146,6 +146,11 @@ impl dyn KernelInterface {
 
     pub fn openwrt_reset_network(&self) -> Result<(), KernelInterfaceError> {
         self.run_command("/etc/init.d/network", &["restart"])?;
+        Ok(())
+    }
+
+    pub fn openwrt_reset_dnsmasq(&self) -> Result<(), KernelInterfaceError> {
+        self.run_command("/etc/init.d/dnsmasq", &["restart"])?;
         Ok(())
     }
 }

--- a/rita_bin/src/client.rs
+++ b/rita_bin/src/client.rs
@@ -29,7 +29,7 @@ use rita_client::dashboard::start_client_dashboard;
 use rita_client::get_client_usage;
 use rita_client::rita_loop::start_antenna_forwarder;
 use rita_client::rita_loop::start_rita_client_loops;
-use rita_client::rita_loop::update_resolv_conf;
+use rita_client::rita_loop::update_dns_conf;
 use rita_client::rita_loop::update_system_time;
 use rita_client::Args;
 use rita_common::debt_keeper::save_debt_on_shutdown;
@@ -151,7 +151,9 @@ fn main() {
     start_core_rita_endpoints(4);
     start_client_dashboard(settings.network.rita_dashboard_port);
     start_antenna_forwarder(settings);
-    update_resolv_conf();
+
+    // utility and rescue fucntions, these perform some upgrade or check
+    update_dns_conf();
     update_system_time();
 
     if let Err(e) = system.run() {


### PR DESCRIPTION
This patch adds some code to rita client that updates the dns server list provided by the internal router dhcp server to clients.

This is important because so far we have been handing out 1.1.1.1 and 8.8.8.8 as the first servers on this list. While modern linux resolvers will round robin and fallback to later entires some devices do not. Meaning we have users in the field who simply see dns errors when their devices does not get a response from the first server on this list.

There are of course many devices that go out to their own servers as fallbacks or can otherwise recover from these errors.

This change helps handle those less robust devices by directing their queries to the local router, who will then forward them to the exit internal dns server primarily, but fallback with other servers in the routers resolve.conf list if that server is down.