### PR TITLE
Increase max-rtt-penality to 2000

### DIFF
--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -218,7 +218,7 @@ pub fn set_metric_factor(stream: &mut TcpStream, new_factor: u32) -> Result<(), 
 }
 
 pub fn monitor(stream: &mut TcpStream, iface: &str) -> Result<(), BabelMonitorError> {
-    let command = &format!("interface {iface} max-rtt-penalty 500 enable-timestamps true");
+    let command = &format!("interface {iface} max-rtt-penalty 2000 enable-timestamps true");
     let iface = iface.to_string();
     let result = run_command(stream, command)?;
 


### PR DESCRIPTION
By doing this we are increasing the scale at which the babel metric increases when going from rtt-min to rtt-max, thereby increasing the weight of latency in metric computation. This allows exit switcher to make better decision based on babel metric