### PR TITLE
Validate payment with Usage History before adding pmt

### DIFF
--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -794,7 +794,6 @@ fn handle_tx_messaging(transaction: TransactionDetails, ts: ToValidate, current_
                 pmt.amount,
                 denom.expect("How did this happen when we already verified existence"),
             );
-
             // update the usage tracker with the details of this payment
             update_payments(pmt);
         }
@@ -819,13 +818,13 @@ fn handle_tx_messaging(transaction: TransactionDetails, ts: ToValidate, current_
                 tx: ts,
                 success: true,
             });
+
             // update debt keeper with the details of this payment
             let _ = payment_succeeded(
                 pmt.to,
                 pmt.amount,
                 denom.expect("How did this happen when we already verified existence"),
             );
-
             // update the usage tracker with the details of this payment
             update_payments(pmt.clone());
 


### PR DESCRIPTION
This commit fixes the following edge case. Router A is paying B. B reboots and loses all payment history in payment validator. Next time A sends all its txids over, B revalidates pmts that have already been accounted for  leading to double counting. This patch fixes that by looking through entire usage history for the payment txid before adding that payment to debt keeper and usage tracker