### PR TITLE
Optimize exit enforcment flow creation

### DIFF
--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -23,8 +23,7 @@ impl dyn KernelInterface {
         listen_port: u16,
         private_key_path: &str,
         if_name: &str,
-        ipv6_filter_handles: HashSet<(String, u32)>,
-    ) -> Result<HashSet<(String, u32)>, Error> {
+    ) -> Result<(), Error> {
         let command = "wg".to_string();
 
         let mut args = vec![
@@ -74,36 +73,7 @@ impl dyn KernelInterface {
             }
         }
 
-        // setup traffic classes for enforcement with flow id's derived from the ip
-        // only get the flows list once
-        let mut mut_handles = ipv6_filter_handles;
-        let flows = self.get_flows(if_name)?;
-        for c in clients.iter() {
-            // Add ipv4 flows
-            let ipv4;
-            match c.internal_ip {
-                IpAddr::V4(addr) => {
-                    ipv4 = addr;
-                    if !self.has_flow_bulk(addr, &flows) {
-                        self.create_flow_by_ip(if_name, addr)?;
-                    }
-                }
-                _ => panic!("Could not derive ipv4 addr for client! Corrupt DB!"),
-            }
-
-            // Add ipv6 flows
-            for ip_net in c.internet_ipv6_list.iter() {
-                if !self.has_flow_bulk_ipv6(ipv4, if_name, &mut mut_handles) {
-                    self.create_flow_by_ipv6(if_name, *ip_net, ipv4)?;
-                    // Add this ipv6 handle to TcDatastore
-                    let class_id = self.get_class_id(ipv4);
-                    let to_add = (if_name.to_string(), class_id);
-                    mut_handles.insert(to_add);
-                }
-            }
-        }
-
-        Ok(mut_handles)
+        Ok(())
     }
 
     /// This function adds a route for each client ipv4 subnet to the routing table

--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -8,7 +8,7 @@ use ipnetwork::IpNetwork;
 
 use crate::KernelInterface;
 use crate::KernelInterfaceError as Error;
-use std::collections::HashSet;
+
 use std::net::Ipv4Addr;
 
 impl dyn KernelInterface {
@@ -63,21 +63,6 @@ impl dyn KernelInterface {
     pub fn has_flow_bulk(&self, ip: Ipv4Addr, tc_out: &str) -> bool {
         let class_id = self.get_class_id(ip);
         tc_out.contains(&format!("1:{class_id}"))
-    }
-
-    /// This function is the ipv6 version of has_flow_bulk, but is different in how its implemented. Since we simply cant
-    /// check for a handle to verify an ipv6 handle, we use a datastore to store a mapping for (interface, class_id)
-    pub fn has_flow_bulk_ipv6(
-        &self,
-        ipv4: Ipv4Addr,
-        iface: &str,
-        ipv6_filter_handles: &mut HashSet<(String, u32)>,
-    ) -> bool {
-        let class_id = self.get_class_id(ipv4);
-        if ipv6_filter_handles.contains(&(iface.to_string(), class_id)) {
-            return true;
-        }
-        false
     }
 
     /// Determines if the provided flow is assigned

--- a/rita_exit/src/database/mod.rs
+++ b/rita_exit/src/database/mod.rs
@@ -22,7 +22,9 @@ use crate::database::struct_tools::to_exit_client;
 use crate::database::struct_tools::to_identity;
 use crate::database::struct_tools::verif_done;
 use crate::get_client_ipv6;
+use crate::rita_loop::EXIT_INTERFACE;
 use crate::rita_loop::EXIT_LOOP_TIMEOUT;
+use crate::rita_loop::LEGACY_INTERFACE;
 use crate::RitaExitError;
 use crate::EXIT_ALLOWED_COUNTRIES;
 use crate::EXIT_DESCRIPTION;
@@ -408,7 +410,7 @@ pub fn setup_clients(
             &wg_clients,
             settings::get_rita_exit().exit_network.wg_tunnel_port,
             &settings::get_rita_exit().exit_network.wg_private_key_path,
-            "wg_exit",
+            LEGACY_INTERFACE,
         );
 
         match exit_status {
@@ -428,7 +430,7 @@ pub fn setup_clients(
             &wg_clients,
             settings::get_rita_exit().exit_network.wg_v2_tunnel_port,
             &settings::get_rita_exit().network.wg_private_key_path,
-            "wg_exit_v2",
+            EXIT_INTERFACE,
         );
 
         match exit_status_new {
@@ -458,12 +460,12 @@ pub fn setup_clients(
     // 3.) Compare this to our datastore of previous clients we set up routes for
     // 4.) Set up routes for v2 or v1 based on this
     let new_wg_exit_clients_timestamps: HashMap<WgKey, SystemTime> = KI
-        .get_last_active_handshake_time("wg_exit_v2")
+        .get_last_active_handshake_time(EXIT_INTERFACE)
         .expect("There should be a new wg_exit interface")
         .into_iter()
         .collect();
     let wg_exit_clients_timestamps: HashMap<WgKey, SystemTime> = KI
-        .get_last_active_handshake_time("wg_exit")
+        .get_last_active_handshake_time(LEGACY_INTERFACE)
         .expect("There should be a wg_exit interface")
         .into_iter()
         .collect();
@@ -505,7 +507,7 @@ pub fn setup_clients(
             KI.setup_individual_client_routes(
                 c.internal_ip.parse().expect("Invalid ipv4 in the db!"),
                 internal_ip_v4.into(),
-                "wg_exit",
+                LEGACY_INTERFACE,
             );
         }
     }
@@ -528,22 +530,20 @@ fn find_changed_clients(
     all_v1: HashMap<WgKey, SystemTime>,
     clients_list: &[exit_db::models::Client],
 ) -> CurrentExitClientState {
-    let wg_exit = "wg_exit".to_string();
     let mut v1_clients = HashSet::new();
 
-    let wg_exit_v2 = "wg_exit_v2".to_string();
     let mut v2_clients = HashSet::new();
 
     // Look at handshakes of each client to determine if they are a V1 or V2 client
     for c in clients_list {
         match get_client_interface(c, all_v2.clone(), all_v1.clone()) {
             Ok(interface) => {
-                if interface == wg_exit {
+                if interface == ClientInterfaceType::LegacyInterface {
                     v1_clients.insert(match c.wg_pubkey.parse() {
                         Ok(a) => a,
                         Err(_) => continue,
                     });
-                } else if interface == wg_exit_v2 {
+                } else if interface == ClientInterfaceType::ExitInterface {
                     v2_clients.insert(match c.wg_pubkey.parse() {
                         Ok(a) => a,
                         Err(_) => continue,
@@ -570,11 +570,17 @@ fn find_changed_clients(
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum ClientInterfaceType {
+    LegacyInterface,
+    ExitInterface,
+}
+
 pub fn get_client_interface(
     c: &exit_db::models::Client,
     new_wg_exit_clients: HashMap<WgKey, SystemTime>,
     wg_exit_clients: HashMap<WgKey, SystemTime>,
-) -> Result<String, Box<RitaExitError>> {
+) -> Result<ClientInterfaceType, Box<RitaExitError>> {
     trace!(
         "New list is {:?} \n Old list is {:?}",
         new_wg_exit_clients,
@@ -590,13 +596,13 @@ pub fn get_client_interface(
             Err(e) => return Err(Box::new(e.clone().into())),
         }),
     ) {
-        (Some(_), None) => Ok("wg_exit_v2".into()),
-        (None, Some(_)) => Ok("wg_exit".into()),
+        (Some(_), None) => Ok(ClientInterfaceType::ExitInterface),
+        (None, Some(_)) => Ok(ClientInterfaceType::LegacyInterface),
         (Some(new), Some(old)) => {
             if new > old {
-                Ok("wg_exit_v2".into())
+                Ok(ClientInterfaceType::ExitInterface)
             } else {
-                Ok("wg_exit".into())
+                Ok(ClientInterfaceType::LegacyInterface)
             }
         }
         _ => {
@@ -604,7 +610,7 @@ pub fn get_client_interface(
                 "WG EXIT SETUP: Client {}, does not have handshake with any wg exit interface. Setting up routes on wg_exit",
                 c.wg_pubkey
             );
-            Ok("wg_exit".into())
+            Ok(ClientInterfaceType::LegacyInterface)
         }
     }
 }
@@ -659,29 +665,32 @@ pub fn enforce_exit_clients(
                         if debt_entry.payment_details.action == DebtAction::SuspendTunnel {
                             info!("Exit is enforcing on {} because their debt of {} is greater than the limit of {}", client.wg_pubkey, debt_entry.payment_details.debt, close_threshold);
                             // create ipv4 and ipv6 flows, which are used to classify traffic, we can then limit the class specifically
-                            if let Err(e) = KI.create_flow_by_ip("wg_exit", ip) {
+                            if let Err(e) = KI.create_flow_by_ip(LEGACY_INTERFACE, ip) {
                                 error!("Failed to setup flow for wg_exit {:?}", e);
                             }
-                            if let Err(e) = KI.create_flow_by_ip("wg_exit_v2", ip) {
+                            if let Err(e) = KI.create_flow_by_ip(EXIT_INTERFACE, ip) {
                                 error!("Failed to setup flow for wg_exit_v2 {:?}", e);
                             }
                             // gets the client ipv6 flow for this exit specifically
                             let client_ipv6 = get_client_ipv6(client);
                             if let Ok(Some(client_ipv6)) = client_ipv6 {
                                 if let Err(e) =
-                                    KI.create_flow_by_ipv6("wg_exit_v2", client_ipv6, ip)
+                                    KI.create_flow_by_ipv6(EXIT_INTERFACE, client_ipv6, ip)
                                 {
                                     error!("Failed to setup ipv6 flow for wg_exit_v2 {:?}", e);
                                 }
                             }
 
-                            if let Err(e) =
-                                KI.set_class_limit("wg_exit", free_tier_limit, free_tier_limit, ip)
-                            {
+                            if let Err(e) = KI.set_class_limit(
+                                LEGACY_INTERFACE,
+                                free_tier_limit,
+                                free_tier_limit,
+                                ip,
+                            ) {
                                 error!("Unable to setup enforcement class on wg_exit: {:?}", e);
                             }
                             if let Err(e) = KI.set_class_limit(
-                                "wg_exit_v2",
+                                EXIT_INTERFACE,
                                 free_tier_limit,
                                 free_tier_limit,
                                 ip,
@@ -690,8 +699,8 @@ pub fn enforce_exit_clients(
                             }
                         } else {
                             let action_required = match (
-                                KI.has_class(ip, "wg_exit"),
-                                KI.has_class(ip, "wg_exit_v2"),
+                                KI.has_class(ip, LEGACY_INTERFACE),
+                                KI.has_class(ip, EXIT_INTERFACE),
                             ) {
                                 (Ok(a), Ok(b)) => a | b,
                                 (Ok(a), Err(_)) => a,
@@ -705,11 +714,11 @@ pub fn enforce_exit_clients(
                                 // Delete exisiting enforcement class, users who are not enforced are unclassifed becuase
                                 // leaving the class in place reduces their speeds.
                                 info!("Deleting enforcement classes for {}", client.wg_pubkey);
-                                if let Err(e) = KI.delete_class("wg_exit", ip) {
+                                if let Err(e) = KI.delete_class(LEGACY_INTERFACE, ip) {
                                     error!("Unable to delete class on wg_exit, is {} still enforced when they shouldnt be? {:?}", ip, e);
                                 }
 
-                                if let Err(e) = KI.delete_class("wg_exit_v2", ip) {
+                                if let Err(e) = KI.delete_class(EXIT_INTERFACE, ip) {
                                     error!("Unable to delete class on wg_exit_v2, is {} still enforced when they shouldnt be? {:?}", ip, e);
                                 }
                             }

--- a/rita_exit/src/operator_update/mod.rs
+++ b/rita_exit/src/operator_update/mod.rs
@@ -8,6 +8,7 @@ use rita_common::KI;
 use std::time::{Duration, Instant};
 
 use crate::database::signup_client;
+use crate::rita_loop::EXIT_INTERFACE;
 
 pub struct UptimeStruct {
     pub prev_time: Duration,
@@ -57,7 +58,7 @@ pub async fn operator_update() {
                 pass,
                 exit_uptime: RITA_UPTIME.elapsed(),
                 // Since this checkin works only from b20, we only need to look on wg_exit_v2
-                users_online: KI.get_wg_exit_clients_online("wg_exit_v2").ok(),
+                users_online: KI.get_wg_exit_clients_online(EXIT_INTERFACE).ok(),
             })
             .await;
 

--- a/rita_exit/src/traffic_watcher/mod.rs
+++ b/rita_exit/src/traffic_watcher/mod.rs
@@ -26,6 +26,8 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use crate::rita_loop::EXIT_INTERFACE;
+use crate::rita_loop::LEGACY_INTERFACE;
 use crate::RitaExitError;
 
 lazy_static! {
@@ -163,11 +165,11 @@ fn debts_logging(debts: &HashMap<Identity, i128>) {
     }
     info!("Total exit income of {:?} Wei this round", total_income);
 
-    match KI.get_wg_exit_clients_online("wg_exit") {
+    match KI.get_wg_exit_clients_online(LEGACY_INTERFACE) {
         Ok(users) => info!("Total of {} wg_exit users online", users),
         Err(e) => warn!("Getting clients failed with {:?}", e),
     }
-    match KI.get_wg_exit_clients_online("wg_exit_v2") {
+    match KI.get_wg_exit_clients_online(EXIT_INTERFACE) {
         Ok(users) => info!("Total of {} wg_exit_v2 users online", users),
         Err(e) => warn!("Getting clients failed with {:?}", e),
     }
@@ -203,7 +205,7 @@ pub fn watch(
     let id_from_ip = ret.ip_to_id;
     let destinations = get_babel_info(routes, our_id, id_from_ip);
 
-    let counters = match KI.read_wg_counters("wg_exit") {
+    let counters = match KI.read_wg_counters(LEGACY_INTERFACE) {
         Ok(res) => res,
         Err(e) => {
             warn!(
@@ -214,7 +216,7 @@ pub fn watch(
         }
     };
 
-    let new_counters = match KI.read_wg_counters("wg_exit_v2") {
+    let new_counters = match KI.read_wg_counters(EXIT_INTERFACE) {
         Ok(res) => res,
         Err(e) => {
             warn!(


### PR DESCRIPTION
Enforcement on the exits for clients has two parts, one where we create a classifier in tc that is used to classify traffic for a specific ip and then another where we take the traffic class we have assigned a given ip to and throttle that traffic class.

When we upgraded to ipv6 exits we the code added traffic classes to every exit interface for every possible user and each user ipv6 ip. For reference if there are 1k active users across 6 different exits with distinct ipv6 ip's that means there where 7k different classes on the exit interface despite it not being possible to use 5/7 of those ips at all! Even worse only a few hundred of those users would be active, and an even smaller number enforced. But the exit kernel spends time attempting to sort every incoming ip into one of those classes.

This change makes it so that we only create the class when it is time to enforce on a specific user, decreasing the scope of traffic classification from nearly 10k ip's down to probably about 100 at most.