### PR TITLE
Payment validation improvements

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -335,13 +335,20 @@ pub struct LightClientLocalIdentity {
 /// This represents a generic payment that may be to or from us
 /// it contains a txid from a published transaction
 /// that should be validated against the blockchain
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct PaymentTx {
     pub to: Identity,
     pub from: Identity,
     pub amount: Uint256,
     // txhash of the payment this could either be on Ethereum or Althea as both are 256 bit integers
     pub txid: Uint256,
+}
+
+// Ensure that duplicate txid are always treated as the same object
+impl Hash for PaymentTx {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.txid.hash(state);
+    }
 }
 
 /// This represents a generic payment that may be to or from us, it does not contain a txid meaning it is

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -333,17 +333,35 @@ pub struct LightClientLocalIdentity {
 }
 
 /// This represents a generic payment that may be to or from us
-/// when completed it contains a txid from a published transaction
+/// it contains a txid from a published transaction
 /// that should be validated against the blockchain
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct PaymentTx {
     pub to: Identity,
     pub from: Identity,
     pub amount: Uint256,
-    // populated when transaction is published
-    pub txid: Option<Uint256>,
-    // althea chain tx reciept
-    pub tx_hash: Option<String>,
+    // txhash of the payment this could either be on Ethereum or Althea as both are 256 bit integers
+    pub txid: Uint256,
+}
+
+/// This represents a generic payment that may be to or from us, it does not contain a txid meaning it is
+/// unpublished
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct UnpublishedPaymentTx {
+    pub to: Identity,
+    pub from: Identity,
+    pub amount: Uint256,
+}
+
+impl UnpublishedPaymentTx {
+    pub fn publish(&self, txid: Uint256) -> PaymentTx {
+        PaymentTx {
+            to: self.to,
+            from: self.from,
+            amount: self.amount,
+            txid,
+        }
+    }
 }
 
 /// This enum contains information about what type of update we need to perform on a router initiated from op tools.

--- a/rita_client/src/operator_fee_manager/mod.rs
+++ b/rita_client/src/operator_fee_manager/mod.rs
@@ -151,8 +151,7 @@ pub async fn tick_operator_payments() {
                     to: operator_identity,
                     from: our_id,
                     amount: amount_to_pay,
-                    txid: Some(txid),
-                    tx_hash: None,
+                    txid: txid,
                 });
                 add_tx_to_total(amount_to_pay);
                 state.operator_debt -= amount_to_pay;

--- a/rita_client/src/operator_fee_manager/mod.rs
+++ b/rita_client/src/operator_fee_manager/mod.rs
@@ -151,7 +151,7 @@ pub async fn tick_operator_payments() {
                     to: operator_identity,
                     from: our_id,
                     amount: amount_to_pay,
-                    txid: txid,
+                    txid,
                 });
                 add_tx_to_total(amount_to_pay);
                 state.operator_debt -= amount_to_pay;

--- a/rita_common/src/debt_keeper/mod.rs
+++ b/rita_common/src/debt_keeper/mod.rs
@@ -21,8 +21,9 @@ use crate::tunnel_manager::TunnelStateChange;
 use crate::RitaCommonError;
 
 use althea_types::Denom;
+use althea_types::Identity;
 use althea_types::SystemChain;
-use althea_types::{Identity, PaymentTx};
+use althea_types::UnpublishedPaymentTx;
 use num256::{Int256, Uint256};
 use num_traits::identities::Zero;
 use num_traits::CheckedMul;
@@ -314,7 +315,7 @@ pub fn send_debt_update() -> Result<(), RitaCommonError> {
                         ));
                     }
                 }
-                queue_payment(PaymentTx {
+                queue_payment(UnpublishedPaymentTx {
                     to: *to,
                     from: match settings::get_rita_common().get_identity() {
                         Some(id) => id,
@@ -325,8 +326,6 @@ pub fn send_debt_update() -> Result<(), RitaCommonError> {
                         }
                     },
                     amount,
-                    txid: None, // not yet published
-                    tx_hash: None,
                 });
             }
         }

--- a/rita_common/src/error.rs
+++ b/rita_common/src/error.rs
@@ -32,6 +32,8 @@ pub enum RitaCommonError {
     BincodeError(Box<bincode::ErrorKind>),
     SendRequestError(SendRequestError),
     JsonPayloadError(JsonPayloadError),
+    DuplicatePayment,
+    PaymentFailed(String),
 }
 
 impl From<LoggerError> for RitaCommonError {
@@ -106,6 +108,8 @@ impl Display for RitaCommonError {
                 f, "Capacity Error: {a}",
             ),
             RitaCommonError::MiscStringError(a) => write!(f, "{a}",),
+            RitaCommonError::PaymentFailed(a) => write!(f, "{a}",),
+            RitaCommonError::DuplicatePayment => write!(f, "Duplicated payment!",),
             RitaCommonError::KernelInterfaceError(a) => write!(f, "{a}",),
             RitaCommonError::StdError(a) => write!(f, "{a}",),
             RitaCommonError::Lowest20Error(a) => write!(

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -6,10 +6,10 @@
 use crate::blockchain_oracle::{
     get_oracle_balance, get_oracle_latest_gas_price, get_oracle_nonce, set_oracle_nonce,
 };
-use crate::debt_keeper::{normalize_payment_amount, payment_failed};
-use crate::payment_validator::{
-    get_payment_txids, validate_later, ToValidate, ALTHEA_CHAIN_PREFIX, ALTHEA_CONTACT_TIMEOUT,
-};
+use crate::debt_keeper::normalize_payment_amount;
+use crate::debt_keeper::payment_failed;
+use crate::payment_validator::{get_payment_txids, validate_later, ToValidate};
+use crate::payment_validator::{ALTHEA_CHAIN_PREFIX, ALTHEA_CONTACT_TIMEOUT};
 use crate::rita_loop::get_web3_server;
 use althea_types::interop::UnpublishedPaymentTx;
 use althea_types::SystemChain;

--- a/rita_common/src/simulated_txfee_manager/mod.rs
+++ b/rita_common/src/simulated_txfee_manager/mod.rs
@@ -93,7 +93,7 @@ pub async fn tick_simulated_tx() {
                 to: txfee_identity,
                 from: our_id,
                 amount: amount_to_pay,
-                txid: txid,
+                txid,
             });
 
             // update the billing now that the payment has gone through

--- a/rita_common/src/simulated_txfee_manager/mod.rs
+++ b/rita_common/src/simulated_txfee_manager/mod.rs
@@ -93,8 +93,7 @@ pub async fn tick_simulated_tx() {
                 to: txfee_identity,
                 from: our_id,
                 amount: amount_to_pay,
-                txid: Some(txid),
-                tx_hash: None,
+                txid: txid,
             });
 
             // update the billing now that the payment has gone through

--- a/rita_common/src/usage_tracker/mod.rs
+++ b/rita_common/src/usage_tracker/mod.rs
@@ -551,7 +551,7 @@ pub fn save_usage_on_shutdown() {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
 
     use super::MINIMUM_NUMBER_OF_TRANSACTIONS_LARGE_STORAGE;
     use super::{get_current_hour, FormattedPaymentTx, PaymentHour, UsageHour, UsageTracker};
@@ -710,8 +710,8 @@ mod tests {
         id
     }
 
-    // generates a random identity, never use in production, your money will be stolen
-    fn random_identity() -> Identity {
+    /// generates a random identity, never use in production, your money will be stolen
+    pub fn random_identity() -> Identity {
         let secret: [u8; 32] = rand::random();
         let mut ip: [u8; 16] = [0; 16];
         ip.copy_from_slice(&secret[0..16]);


### PR DESCRIPTION
This contains two patches.

###  Improve payment duplicates check

This patch corrects some glaring errors in the payments duplicates check
that has been causing the exits specifically to accept all payments
twice and give double credit.

The crux of the issue is that when the function to_validate was called
it did not check payments currently waiting to be verified.

This is probably because the to_verify list is a hashset, so it would in
the past automatically reject duplicates. But at some point an Instant
for the time we recieved the payment was added. This did not produce any
immediate problems, but many months or even years later make_payments_v2
was introduced, this new payments endpoint had routers play back their
full local payment history to ensure the other router was in sync
despite reboots/crashes.

This means that a new payment, with a differnet value for the instant
recieved could be inserted into the to_validate list if for some reason
a second call of make_paymetns_v2 was called within a short amount of
time.

This case happens to be very common on the exits during high bandwidth
periods. One tx will go through and within less than a minute another
one will go through as well. But thanks to make_payments_v2 the last
payment was inserted with a new instant when the next payment was also
being added. Resulting in a duplicate and double credit.

In order to remove this issue several steps have been taken

1) an explicit check of payments in flight has been added to to_validate
2) The ToValidate struct now has a custom implementation of hash which
   only inspects the txid, meaning the hashset duplicate prevention
   works again. This is a redundant check in case (1) fails
3) A special error type for duplicate payment has been added which is
   then used by two new unit tests to confirm that (1) remains
   functional

### Use combined txid for Althea payments

This patch uses a combined txid for Althea payments and xdai paymetns
this removes an extra field to check and optionality from the struct.
Also in this change the txid field in paymentx is now mandatory with a
new type UnpublishedPaymentTx taking it's place in situations where it
would be none.

This helps enforce correctness via types and generally prevent
accidents.